### PR TITLE
Fix 149 deps

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -114,7 +114,7 @@
 ParamSet = R6Class("ParamSet",
   public = list(
     params = NULL,
-    deps = NULL, # a list of Dependency objects
+    deps = list(), # a list of Dependency objects
 
     initialize = function(params = list()) {
       assert_list(params, types = "Param")

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -168,6 +168,9 @@ test_that("ParamSet$clone can be deep", {
   ps2$deps[[1L]]$param$id = "foo"
   expect_equal(ps2$deps[[1L]]$param$id, "foo")
   expect_equal(ps1$deps[[1L]]$param$id, "x")
+
+  ps = ParamSet$new()
+  expect_equal(ps, ps$clone(deep = TRUE))
 })
 
 test_that("ParamSet$is_bounded", {


### PR DESCRIPTION
make clone(deep = TRUE) all.equal to original by fixing `deps` to `list()` on init.