### PR TITLE
Allow ParamSetCollection members with empty set_id

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -9,8 +9,8 @@
 #' some parameters to constant values (regarding subsequent sampling or generation of designs).
 #'
 #' @section Public members / active bindings:
-#' * `set_id`            :: `character(1) | NULL` \cr
-#'   ID of this param set. Settable.
+#' * `set_id`            :: `character(1)` \cr
+#'   ID of this param set. Default `""`. Settable.
 #' * `params`            :: named list of [Param] \cr
 #'   Contained parameters, named with their respective IDs.
 #'   NB: The returned list contains references, so you can potentially change the objects of the param set by writing to them.

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -9,7 +9,7 @@
 #' some parameters to constant values (regarding subsequent sampling or generation of designs).
 #'
 #' @section Public members / active bindings:
-#' * `set_id`            :: `character(1)` \cr
+#' * `set_id`            :: `character(1) | NULL` \cr
 #'   ID of this param set. Settable.
 #' * `params`            :: named list of [Param] \cr
 #'   Contained parameters, named with their respective IDs.
@@ -121,7 +121,7 @@ ParamSet = R6Class("ParamSet",
       ids = map_chr(params, "id")
       assert_names(ids, type = "strict")
       private$.params = set_names(map(params, function(p) p$clone(deep = TRUE)), ids)
-      self$set_id = "paramset"
+      self$set_id = ""
     },
 
     add = function(p) {
@@ -297,8 +297,10 @@ ParamSet = R6Class("ParamSet",
       if (missing(v)) {
         private$.set_id
       } else {
-        assert_id(v)
-        assert_names(v, type = "strict")
+        if (!identical(v, "")) {
+          assert_id(v)
+          assert_names(v, type = "strict")
+        }
         private$.set_id = v
       }
     },

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -5,8 +5,8 @@
 #' A collection of multiple [ParamSet] objects.
 #' * The collection is basically a light-weight wrapper / container around references to multiple sets.
 #' * In order to ensure unique param names, every param in the collection is referred to with
-#'   "<set_id>.<param_id>". Parameters from ParamSets with no (i.e. `NULL`) `$set_id` are referenced
-#'   directly. Multiple ParamSets with `$set_id` `NULL` can be combined, but their parameter names
+#'   "<set_id>.<param_id>". Parameters from ParamSets with empty (i.e. `""`) `$set_id` are referenced
+#'   directly. Multiple ParamSets with `$set_id` `""` can be combined, but their parameter names
 #'   must be unique.
 #' * Operation `subset` is currently not allowed.
 #' * Operation `add` currently only works when adding complete sets not single params.

--- a/tests/testthat/test_ParamDbl.R
+++ b/tests/testthat/test_ParamDbl.R
@@ -35,6 +35,7 @@ test_that("is_bounded works", {
 })
 
 test_that("qunif", {
+  set.seed(8008135)
   n = 50000L
   testit = function(a, b) {
 

--- a/tests/testthat/test_ParamSetCollection.R
+++ b/tests/testthat/test_ParamSetCollection.R
@@ -5,39 +5,42 @@ test_that("ParamSet basic stuff works", {
   ps1$set_id = "s1"
   ps2 = th_paramset_full()
   ps2$set_id = "s2"
-  psc = ParamSetCollection$new(list(ps1, ps2))
+  ps3 = th_paramset_dbl1()
+  ps3$set_id = ""
+  psc = ParamSetCollection$new(list(ps1, ps2, ps3))
 
   ps1clone = ps1$clone(deep = TRUE)
   ps2clone = ps2$clone(deep = TRUE)
 
-  my_c = function(xs1, xs2) {
+  my_c = function(xs1, xs2, xs3) {
     # littler helper to join to ps-result and prefix names
-    ns = c(paste0("s1.", names(xs1)), paste0("s2.", names(xs2)))
-    set_names(c(xs1, xs2), ns)
+    ns = c(paste0("s1.", names(xs1)), paste0("s2.", names(xs2)), names(xs3))
+    set_names(c(xs1, xs2, xs3), ns)
   }
 
   expect_class(psc, "ParamSetCollection")
-  expect_equal(psc$length, ps1$length + ps2$length)
+  expect_equal(psc$length, ps1$length + ps2$length + ps3$length)
   # check that param internally in collection is constructed correctly
   p = psc$params[[2L]]
   p = p$clone()
   p$id = "th_param_int"
   expect_equal(p, ps2$params[[1L]])
-  expect_equal(psc$ids(), c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids())))
-  expect_equal(psc$lower, my_c(ps1$lower, ps2$lower))
+  expect_equal(psc$ids(), c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids()), ps3$ids()))
+  expect_equal(psc$lower, my_c(ps1$lower, ps2$lower, ps3$lower))
   d = as.data.table(psc)
-  expect_data_table(d, nrows = 5)
+  expect_data_table(d, nrows = 6)
   expect_false(psc$has_deps)
   expect_false(psc$has_trafo)
 
   d = as.data.table(psc)
-  expect_equal(d$id, c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids())))
+  expect_equal(d$id, c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids()), ps3$ids()))
 
   expect_true(psc$check(list(s1.th_param_dbl = 1, s2.th_param_int = 2)))
-  expect_string(psc$check(list(th_param_dbl = 1, th_param_int = 2)), fixed = "not avail")
+  expect_string(psc$check(list(th_param_int = 2)), fixed = "not avail")
+  expect_true(psc$check(list(th_param_dbl = 1)))
 
   d = generate_design_random(psc, n = 10L)
-  expect_data_table(d$data, nrows = 10, ncols = 5L)
+  expect_data_table(d$data, nrows = 10, ncols = 6L)
 
   psc$trafo = function(x, param_set) {
     x$s2.th_param_int = 99
@@ -45,11 +48,11 @@ test_that("ParamSet basic stuff works", {
   }
   expect_true(psc$has_trafo)
   d = generate_design_random(psc, n = 10L)
-  expect_data_table(d$data, nrows = 10, ncols = 5L)
+  expect_data_table(d$data, nrows = 10, ncols = 6L)
   xs = d$transpose(trafo = TRUE)
   for (i in 1:10) {
     x = xs[[i]]
-    expect_list(x, len = 5)
+    expect_list(x, len = 6)
     expect_names(names(x), permutation.of = psc$ids())
     expect_equal(x$s2.th_param_int, 99)
   }
@@ -58,21 +61,21 @@ test_that("ParamSet basic stuff works", {
   expect_equal(ps1, ps1clone)
   expect_equal(ps2, ps2clone)
 
-  expect_output(print(psc), "s1\\.th_param_dbl.*s2\\.th_param_int.*s2\\.th_param_dbl.*s2\\.th_param_fct.*s2\\.th_param_lgl.*")
+  expect_output(print(psc), "s1\\.th_param_dbl.*s2\\.th_param_int.*s2\\.th_param_dbl.*s2\\.th_param_fct.*s2\\.th_param_lgl.*th_param_dbl")
 
   # ps1 and ps2 should not be changed by printing
   expect_equal(ps1, ps1clone)
   expect_equal(ps2, ps2clone)
 
   # adding a set
-  ps3 = ParamSet$new(list(ParamDbl$new("x")))
-  ps3$set_id = "s3"
-  psc$add(ps3)
-  expect_equal(psc$length, ps1$length + ps2$length + ps3$length)
-  expect_equal(psc$ids(), c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids()), paste0("s3.", ps3$ids())))
+  ps4 = ParamSet$new(list(ParamDbl$new("x")))
+  ps4$set_id = "s4"
+  psc$add(ps4)
+  expect_equal(psc$length, ps1$length + ps2$length + ps3$length + ps4$length)
+  expect_equal(psc$ids(), c(paste0("s1.", ps1$ids()), paste0("s2.", ps2$ids()), ps3$ids(), paste0("s4.", ps4$ids())))
   psc$remove_sets("s1")
-  expect_equal(psc$length, ps2$length + ps3$length)
-  expect_equal(psc$ids(), c(paste0("s2.", ps2$ids()), paste0("s3.", ps3$ids())))
+  expect_equal(psc$length, ps2$length + ps3$length + ps4$length)
+  expect_equal(psc$ids(), c(paste0("s2.", ps2$ids()), ps3$ids(), paste0("s4.", ps4$ids())))
 })
 
 test_that("some operations are not allowed", {
@@ -130,11 +133,17 @@ test_that("values", {
     ParamDbl$new("d", lower = 1, upper = 8)
   ))
   ps2$set_id = "bar"
+  ps3 = ParamSet$new(list(
+    ParamDbl$new("x", lower = 1, upper = 8)
+  ))
+  ps4 = ParamSet$new(list(
+    ParamDbl$new("y", lower = 1, upper = 8)
+  ))
 
   ps1clone = ps1$clone(deep = TRUE)
   ps2clone = ps2$clone(deep = TRUE)
 
-  pcs = ParamSetCollection$new(list(ps1, ps2))
+  pcs = ParamSetCollection$new(list(ps1, ps2, ps3, ps4))
   expect_equal(pcs$values, named_list())
   ps2$values = list(d = 3)
   expect_equal(pcs$values, list(bar.d = 3))
@@ -142,8 +151,12 @@ test_that("values", {
   expect_equal(pcs$values, list(foo.d = 8))
   expect_equal(ps1$values, list(d = 8))
   expect_equal(ps2$values, named_list())
+  pcs$values = list(x = 1)
+  expect_equal(pcs$values, list(x = 1))
+  expect_equal(ps3$values, list(x = 1))
 
   ps1clone$values$d = 8
+  pcs$values = list(foo.d = 8)
   ps2$values = list()
   expect_equal(ps1clone, ps1)
   expect_equal(ps2clone, ps2)
@@ -168,12 +181,14 @@ test_that("empty collections", {
 
 test_that("no problems if we name the list of sets", {
   ps = ParamSet$new(list(ParamDbl$new("test1")))
+  ps$set_id = "paramset"
   psc = ParamSetCollection$new(list(prefix = ps))
   expect_equal(names(psc$params), "paramset.test1")
 })
 
 test_that("no warning in printer, see issue 208", {
   ps = ParamSet$new(list(ParamDbl$new("test1")))
+  ps$set_id = "paramset"
   psc = ParamSetCollection$new(list(ps))
   psc$values = list(paramset.test1 = 1)
   expect_warning(capture_output(print(ps)), NA)
@@ -182,12 +197,17 @@ test_that("no warning in printer, see issue 208", {
 
 test_that("collection reflects direct paramset$set_id change", {
   ps = ParamSet$new(list(ParamDbl$new("d")))
+  ps$set_id = "paramset"
   psc = ParamSetCollection$new(list(ps))
   ps$values = list(d = 1)
   expect_equal(psc$values, list(paramset.d = 1))
   ps$set_id = "foo"
   expect_equal(psc$values, list(foo.d = 1))
   expect_equal(psc$params, list(foo.d = ParamDbl$new("foo.d")))
+
+  ps$set_id = ""
+  expect_equal(psc$values, list(d = 1))
+  expect_equal(psc$params, list(d = ParamDbl$new("d")))
 })
 
 
@@ -196,12 +216,17 @@ test_that("collection allows state-change setting of paramvals, see issue 205", 
   ps1$set_id = "s1"
   ps2 = ParamSet$new(list(ParamDbl$new("d2")))
   ps2$set_id = "s2"
-  psc = ParamSetCollection$new(list(ps1, ps2))
+  ps3 = ParamSet$new(list(ParamDbl$new("d3")))
+  ps3$set_id = ""
+
+  psc = ParamSetCollection$new(list(ps1, ps2, ps3))
   expect_equal(psc$values, named_list())
   psc$values$s1.d1 = 1
   expect_equal(psc$values, list(s1.d1 = 1))
   psc$values$s2.d2 = 2
   expect_equal(psc$values, list(s1.d1 = 1, s2.d2 = 2))
+  psc$values$d3 = 3
+  expect_equal(psc$values, list(s1.d1 = 1, s2.d2 = 2, d3 = 3))
 })
 
 test_that("set_id inference in values assignment works now", {
@@ -224,6 +249,10 @@ test_that("set_id inference in values assignment works now", {
 
   expect_error(pscol2$add(pstest), "nameclashes.* a\\.c\\.paramc")
 
+  pstest = ParamSet$new(list(ParamDbl$new("a.c.paramc")))
+  pstest$set_id = ""
+  expect_error(pscol2$add(pstest), "nameclashes.* a\\.c\\.paramc")
+
   pscol2$values = list(a.c.paramc = 3, a.b.parama = 1, a.b.paramb = 2)
 
   expect_equal(psa$values, list(parama = 1))
@@ -231,4 +260,7 @@ test_that("set_id inference in values assignment works now", {
   expect_equal(psc$values, list(paramc = 3))
   expect_equal(pscol1$values, list(b.paramb = 2, c.paramc = 3))
   expect_equal(pscol2$values, list(a.b.parama = 1, a.b.paramb = 2, a.c.paramc = 3))
+
+  expect_error(ParamSetCollection$new(list(pscol1, pstest)),
+    "duplicated parameter.* a\\.c\\.paramc")
 })

--- a/todo-files/development.R
+++ b/todo-files/development.R
@@ -1,0 +1,6 @@
+
+
+devtools::load_all("..")
+
+
+testthat::test_package("paradox")


### PR DESCRIPTION
Changes:
* allow `$set_id` to be `""` (empty name)
* `$set_id` of `ParamSetCollection` now defaults to `""` (empty name)
* `ParamSetCollection` allows member `ParamSet`s that have an empty `$set_id`
* Parameters of `ParamSet`s with non-`""` `$set_id` are accessed by `<set_id>.<param_id>`, as before. Parameters of `ParamSet`s with `$set_id` == `""` are accessed by their parameter id.

```r
> ps1 = ParamSet$new(list(ParamDbl$new("x")))
> ps2 = ParamSet$new(list(ParamDbl$new("y")))
> ps2$set_id = "paramset"
> psc = ParamSetCollection$new(list(ps1, ps2))
> psc
ParamSet: 
           id    class lower upper levels     default value
1:          x ParamDbl  -Inf   Inf        <NoDefault>
2: paramset.y ParamDbl  -Inf   Inf        <NoDefault>
```
closes #222