### PR TITLE
Value Change Callback

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -380,6 +380,10 @@ ParamSet = R6Class("ParamSet",
       }
 
       self$assert(xs)
+      xs = Reduce(function(val, fun) {
+        val = fun(val)
+        self$assert(val)
+      }, self$callbacks, xs)
       if (length(xs) == 0L) xs = named_list()
       private$.values = xs
     },
@@ -390,6 +394,14 @@ ParamSet = R6Class("ParamSet",
 
     extra_values = function() {
       private$.values[names(private$.values) %nin% names(private$.params)]
+    },
+
+    callbacks = function(val) {
+      if (!missing(val)) {
+        assert_list(val, types = "function", any.missing = FALSE)
+        private$.callbacks = val
+      }
+      private$.callbacks
     }
   ),
 
@@ -399,6 +411,7 @@ ParamSet = R6Class("ParamSet",
     .params = NULL,
     .values = named_list(),
     .deps = data.table(id = character(0L), on = character(0L), cond = list()),
+    .callbacks = list(),
     # return a slot / AB, as a named vec, named with id (and can enforce a certain vec-type)
     get_member_with_idnames = function(member, astype) set_names(astype(map(self$params, member)), names(self$params)),
 

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -379,11 +379,9 @@ ParamSet = R6Class("ParamSet",
         return(private$.values)
       }
 
+      xs = Reduce(function(val, fun) fun(val), self$callbacks, xs)
       self$assert(xs)
-      xs = Reduce(function(val, fun) {
-        val = fun(val)
-        self$assert(val)
-      }, self$callbacks, xs)
+
       if (length(xs) == 0L) xs = named_list()
       private$.values = xs
     },

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -115,13 +115,11 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     },
 
     values = function(xs) {
-      sets = private$.sets
-      names(sets) = map_chr(sets, "set_id")
       if (!missing(xs)) {
-        assert_list(xs)
+        xs = Reduce(function(val, fun) fun(val), self$callbacks, xs)
         self$assert(xs) # make sure everything is valid and feasible
 
-        for (s in sets) {
+        for (s in private$.sets) {
           # retrieve sublist for each set, then assign it in set (after removing prefix)
           psids = names(s$params)
           if (s$set_id != "") {
@@ -134,6 +132,8 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
           s$values = pv
         }
       }
+      sets = private$.sets
+      names(sets) = map_chr(sets, "set_id")
       vals = map(sets, "values")
       vals = unlist(vals, recursive = FALSE)
       if (!length(vals)) vals = named_list()


### PR DESCRIPTION
See [tests](https://github.com/mlr-org/paradox/blob/8daebd96c27ad72b271da1cf6236d71b91f2d10c/tests/testthat/test_ParamSet.R#L278) for how exactly this could work. The idea is to have a `$callbacks` slot of functions that get called whenever `$values` changes; the functions get called in turn and return a possibly modified version of the values to be set. This would close #231.