### PR TITLE
Design check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Suggests:
 Encoding: UTF-8
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE, r6 = FALSE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Collate:
     'Condition.R'
     'Design.R'

--- a/R/Sampler.R
+++ b/R/Sampler.R
@@ -39,7 +39,7 @@ Sampler = R6Class("Sampler",
 
     sample = function(n) {
       assert_count(n) # we do argcheck on toplevel
-      Design$new(self$param_set, private$.sample(n), remove_dupl = FALSE) # user wants n points, dont remove
+      Design$new(self$param_set, private$.sample(n), enforce_dependencies = TRUE, remove_dupl = FALSE) # user wants n points, dont remove
     },
 
     print = function(...) {

--- a/R/generate_design_grid.R
+++ b/R/generate_design_grid.R
@@ -55,5 +55,5 @@ generate_design_grid = function(param_set, resolution = NULL, param_resolutions 
   grid_vec = lapply(par_res, function(r) seq(0, 1, length.out = r))
   res = imap(grid_vec, function(value, id) param_set$params[[id]]$qunif(x = value))
   res = cross_join(res, sorted = FALSE)
-  Design$new(param_set, res, remove_dupl = TRUE) # user wants no dupls, remove
+  Design$new(param_set, res, enforce_dependencies = TRUE, remove_dupl = TRUE) # user wants no dupls, remove
 }

--- a/R/generate_design_lhs.R
+++ b/R/generate_design_lhs.R
@@ -40,5 +40,5 @@ generate_design_lhs = function(param_set, n, lhs_fun = NULL) {
   }
   colnames(d) = ids
   d = map_dtc(ids, function(id) param_set$params[[id]]$qunif(d[, id]))
-  Design$new(param_set, set_names(d, ids), remove_dupl = FALSE) # user wants n-points, dont remove
+  Design$new(param_set, set_names(d, ids), enforce_dependencies = TRUE, remove_dupl = FALSE) # user wants n-points, dont remove
 }

--- a/man/Condition.Rd
+++ b/man/Condition.Rd
@@ -5,7 +5,9 @@
 \alias{CondEqual}
 \alias{CondAnyOf}
 \title{Dependency Condition}
-\format{\link[R6:R6Class]{R6::R6Class} object.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object.
+}
 \description{
 Condition object, to specify the condition in a dependency.
 }

--- a/man/Design.Rd
+++ b/man/Design.Rd
@@ -3,7 +3,9 @@
 \name{Design}
 \alias{Design}
 \title{Design of Configurations}
-\format{\link[R6:R6Class]{R6::R6Class} object.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object.
+}
 \description{
 A lightweight wrapper around a \link{ParamSet} and a \code{\link[data.table:data.table]{data.table::data.table()}}, where the
 latter is a design of configurations produced from the former - e.g.,

--- a/man/Design.Rd
+++ b/man/Design.Rd
@@ -10,6 +10,9 @@
 A lightweight wrapper around a \link{ParamSet} and a \code{\link[data.table:data.table]{data.table::data.table()}}, where the
 latter is a design of configurations produced from the former - e.g.,
 by calling a \code{\link[=generate_design_grid]{generate_design_grid()}} or by sampling.
+
+Feasibility of the given \code{data} is checked, except possibly for dependencies: If the
+\code{enforce_dependencies} flag is set, then parameters with unmet dependencies are set to \code{NA}.
 }
 \section{Construction}{
 \preformatted{c = Design$new(param_set, data, remove_dupl)
@@ -20,8 +23,11 @@ Note that the first 2 arguments are NOT cloned during construction!
 \item \code{param_set} :: \code{ParamSet}.
 \item \code{data} :: \code{\link[data.table:data.table]{data.table::data.table()}}\cr
 Right hand side of the condition.
+\item \code{enforce_dependencies} :: \code{logical(1)}\cr
+Whether to set parameters whose dependencies are not met to \code{NA}.
+Default \code{FALSE} (will throw an error if dependencies are not satisfied).
 \item \code{remove_dupl} :: \code{logical(1)}\cr
-Remove duplicates?
+Remove duplicates? Default \code{FALSE}.
 }
 }
 

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -3,7 +3,9 @@
 \name{Param}
 \alias{Param}
 \title{Param Object}
-\format{\link[R6:R6Class]{R6::R6Class} object.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object.
+}
 \description{
 Abstract base class for parameters.
 }

--- a/man/ParamDbl.Rd
+++ b/man/ParamDbl.Rd
@@ -3,7 +3,9 @@
 \name{ParamDbl}
 \alias{ParamDbl}
 \title{Numerical Parameter}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.
+}
 \description{
 A \link{Param} to describe real-valued parameters.
 }

--- a/man/ParamFct.Rd
+++ b/man/ParamFct.Rd
@@ -3,7 +3,9 @@
 \name{ParamFct}
 \alias{ParamFct}
 \title{Factor Parameter}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.
+}
 \description{
 A \link{Param} to describe categorical (factor) parameters.
 }

--- a/man/ParamInt.Rd
+++ b/man/ParamInt.Rd
@@ -3,7 +3,9 @@
 \name{ParamInt}
 \alias{ParamInt}
 \title{Integer Parameter}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.
+}
 \description{
 A \link{Param} to describe integer parameters.
 }

--- a/man/ParamLgl.Rd
+++ b/man/ParamLgl.Rd
@@ -3,7 +3,9 @@
 \name{ParamLgl}
 \alias{ParamLgl}
 \title{Logical Parameter}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.
+}
 \description{
 A \link{Param} to describe logical parameters.
 }

--- a/man/ParamSet.Rd
+++ b/man/ParamSet.Rd
@@ -109,10 +109,12 @@ Adds a single param or another set to this set, all params are cloned.
 \code{character()} -> \code{self} \cr
 Changes the current set to the set of passed IDs.
 \item \code{test(x)}, \code{check(x)}, \code{assert(x)} \cr
-Three \pkg{checkmate}-like check-functions. Takes a named list.
+Three \pkg{checkmate}-like check-functions. Takes a point as a named list, \emph{or} a \code{data.frame} of points.
 A point x is feasible, if it configures a subset of params,
 all individual param constraints are satisfied and all dependencies are satisfied.
-Params for which dependencies are not satisfied should not be part of \code{x}.
+Params for which dependencies are not satisfied should not be part of \code{x}.\cr
+If the given value is a \code{data.frame}, then each line is checked independently. \code{NA} values are
+counted as parameters not given at all for the sake of dependencies and \code{"requires"} tags.
 \item \code{add_dep(id, on, cond)} \cr
 (\code{character(1)}, \code{character(1)}, \link{Condition}) -> \code{self} \cr
 Adds a dependency to this set, so that param \code{id} now depends on param \code{on}.

--- a/man/ParamSetCollection.Rd
+++ b/man/ParamSetCollection.Rd
@@ -3,7 +3,9 @@
 \name{ParamSetCollection}
 \alias{ParamSetCollection}
 \title{ParamSetCollection}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{ParamSet}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{ParamSet}.
+}
 \description{
 A collection of multiple \link{ParamSet} objects.
 \itemize{

--- a/man/ParamUty.Rd
+++ b/man/ParamUty.Rd
@@ -3,7 +3,9 @@
 \name{ParamUty}
 \alias{ParamUty}
 \title{Untyped Parameter}
-\format{\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object inheriting from \link{Param}.
+}
 \description{
 A \link{Param} to describe untyped parameters.
 }

--- a/man/Sampler.Rd
+++ b/man/Sampler.Rd
@@ -3,7 +3,9 @@
 \name{Sampler}
 \alias{Sampler}
 \title{Sampler Class}
-\format{\link[R6:R6Class]{R6::R6Class} object.}
+\format{
+\link[R6:R6Class]{R6::R6Class} object.
+}
 \description{
 This is the abstract base class for sampling objects like \link{Sampler1D}, \link{SamplerHierarchical} or \link{SamplerJointIndep}.
 }

--- a/man/Sampler1D.Rd
+++ b/man/Sampler1D.Rd
@@ -3,7 +3,9 @@
 \name{Sampler1D}
 \alias{Sampler1D}
 \title{Sampler1D Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.
+}
 \description{
 1D sampler, abstract base class for Sampler like \link{Sampler1DUnif}, \link{Sampler1DRfun}, \link{Sampler1DCateg} and \link{Sampler1DNormal}.
 }

--- a/man/Sampler1DCateg.Rd
+++ b/man/Sampler1DCateg.Rd
@@ -3,7 +3,9 @@
 \name{Sampler1DCateg}
 \alias{Sampler1DCateg}
 \title{Sampler1DCateg Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.
+}
 \description{
 Sampling from a discrete distribution, for a \link{ParamFct} or \link{ParamLgl}.
 }

--- a/man/Sampler1DNormal.Rd
+++ b/man/Sampler1DNormal.Rd
@@ -3,7 +3,9 @@
 \name{Sampler1DNormal}
 \alias{Sampler1DNormal}
 \title{Sampler1DNormal Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.
+}
 \description{
 Normal sampling (potentially truncated) for \link{ParamDbl}.
 }

--- a/man/Sampler1DRfun.Rd
+++ b/man/Sampler1DRfun.Rd
@@ -3,7 +3,9 @@
 \name{Sampler1DRfun}
 \alias{Sampler1DRfun}
 \title{Sampler1DRfun Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.
+}
 \description{
 Arbitrary sampling from 1D RNG functions from R.
 }

--- a/man/Sampler1DUnif.Rd
+++ b/man/Sampler1DUnif.Rd
@@ -3,7 +3,9 @@
 \name{Sampler1DUnif}
 \alias{Sampler1DUnif}
 \title{Sampler1DUnif Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler1D}.
+}
 \description{
 Uniform random sampler for arbitrary (bounded) parameters.
 }

--- a/man/SamplerHierarchical.Rd
+++ b/man/SamplerHierarchical.Rd
@@ -3,7 +3,9 @@
 \name{SamplerHierarchical}
 \alias{SamplerHierarchical}
 \title{SamplerHierarchical Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.
+}
 \description{
 Hierarchical sampling for arbitrary param sets with dependencies, where the user specifies 1D samplers per param.
 Dependencies are topologically sorted, parameters are then sampled in topological order,

--- a/man/SamplerJointIndep.Rd
+++ b/man/SamplerJointIndep.Rd
@@ -3,7 +3,9 @@
 \name{SamplerJointIndep}
 \alias{SamplerJointIndep}
 \title{SamplerJointIndep Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{Sampler}.
+}
 \description{
 Create joint, independent sampler out of multiple other samplers.
 }

--- a/man/SamplerUnif.Rd
+++ b/man/SamplerUnif.Rd
@@ -3,7 +3,9 @@
 \name{SamplerUnif}
 \alias{SamplerUnif}
 \title{SamplerUnif Class}
-\format{\link[R6:R6Class]{R6::R6Class} inheriting from \link{SamplerHierarchical}.}
+\format{
+\link[R6:R6Class]{R6::R6Class} inheriting from \link{SamplerHierarchical}.
+}
 \description{
 Uniform random sampling for an arbitrary (bounded) \link{ParamSet}.
 Constructs 1 uniform sampler per \link{Param}, then passes them to \link{SamplerHierarchical}.

--- a/tests/testthat/test_Design.R
+++ b/tests/testthat/test_Design.R
@@ -27,3 +27,15 @@ test_that("transpose works", {
   xs = d$transpose(trafo = TRUE, filter_na = TRUE)
   expect_equal(xs, list(list(f = "a", i = 11L), list(f = "b")))
 })
+
+test_that("design throws if data is bad", {
+
+  ps = ParamSet$new(list(
+    ParamFct$new("f", levels = c("a", "b")),
+    ParamInt$new("i", lower = 1, upper = 5)
+  ))
+  data = data.table(f = c("a", "b"), i = c(1, 10))
+
+  expect_error(Design$new(ps, data), "Line 2.*is not <= 5")
+
+})

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -101,6 +101,11 @@ test_that("ParamSet$check", {
   expect_true(ps$check(list(th_param_dbl = 5)))
   expect_true(ps$check(list(th_param_int = 5)))
 
+  expect_character(ps$check(data.frame(th_param_dbl = 5, new_param = NA)), fixed = "not available")
+  expect_character(ps$check(data.frame(th_param_dbl = 5, th_param_intx = NA)), fixed = "Did you mean")
+  expect_match(ps$check(data.frame(th_param_dbl = c(5, 5), th_param_int = c(5, 15))), "ine 2.*not <= 10")
+  expect_true(ps$check(data.frame(th_param_dbl = 5)))
+
   ps = ParamLgl$new("x")$rep(2)
   ps$add_dep("x_rep_1", "x_rep_2", CondEqual$new(TRUE))
   expect_string(ps$check(list(x_rep_1 = FALSE, x_rep_2 = FALSE)), fixed = "x_rep_2 = TRUE")


### PR DESCRIPTION
Closes #268

This is a bit of an "opinionated" PR:

* checking a df against a ParamSet could have been done with a new function (either member of ParamSet or global), but instead the `$check()` is polymorphic now. This gives us `$assert` and `$test` for free. Note I had to split up `$check` for the common stuff between `data.frame` and `list` to avoid unnecessary repeated checks of parameter names in the `data.frame` case
* `Design$new()` now checks for feasibility of its argument, because implicitly users of this were assuming that it does (principle of least surprise)
* `Design$new()` used to "enforce" dependencies; this is optional now and does not happen by default (see point above). This may break one or two users somewhere that relying on default enforcement of deps.
* `Design$new()` parameter `remove_dupl` defaults to `FALSE` now because that is obviously the right choice for a default here.

If there are small problems with this please fix or delegate to a ~hiwi~contributor.