### PR TITLE
fix test for new data.table

### DIFF
--- a/tests/testthat/test_param_vals.R
+++ b/tests/testthat/test_param_vals.R
@@ -18,7 +18,7 @@ test_that("values", {
   expect_true(ps$check(list(d = 1, f = "a")))
   expect_equal(ps2$values, list(d = 0.5))
   # check printer
-  expect_output(print(ps2), "d.*<NoDefault\\[3\\]>.*0.5")
+  expect_output(print(ps2), "d.*<NoDefault(?:\\[3\\])?>.*0.5")
 
   ps2 = ps$clone()
   ps2$subset(ids = c("i"))

--- a/tests/testthat/test_param_vals.R
+++ b/tests/testthat/test_param_vals.R
@@ -18,7 +18,7 @@ test_that("values", {
   expect_true(ps$check(list(d = 1, f = "a")))
   expect_equal(ps2$values, list(d = 0.5))
   # check printer
-  expect_output(print(ps2), "d.*<NoDefault>.*0.5")
+  expect_output(print(ps2), "d.*<NoDefault\\[3\\]>.*0.5")
 
   ps2 = ps$clone()
   ps2$subset(ids = c("i"))


### PR DESCRIPTION
Closes #290 

The `(?: ... )?` part is to make the test flexible enough to pass before and after the update. `[^>]*>` would also work i think.