### PR TITLE
CondEqual uses identical()

### DIFF
--- a/R/Condition.R
+++ b/R/Condition.R
@@ -66,7 +66,7 @@ Condition = R6Class("Condition",
 CondEqual = R6Class("CondEqual", inherit = Condition,
   public = list(
     initialize = function(rhs) super$initialize("equal", rhs),
-    test = function(x) !is.na(x) & x == self$rhs,
+    test = function(x) !is.na(x) && identical(x, self$rhs),
     as_string = function(lhs_chr = "x") sprintf("%s = %s", lhs_chr, as.character(self$rhs))
   )
 )
@@ -75,7 +75,7 @@ CondEqual = R6Class("CondEqual", inherit = Condition,
 CondAnyOf = R6Class("CondAnyOf", inherit = Condition,
   public = list(
     initialize = function(rhs) super$initialize("anyof", rhs),
-    test = function(x) !is.na(x) & x %in% self$rhs,
+    test = function(x) !is.na(x) && x %in% self$rhs,
     as_string = function(lhs_chr = "x") sprintf("%s \u2208 {%s}", lhs_chr, str_collapse(self$rhs))
   )
 )


### PR DESCRIPTION
Fix the logic in CondEqual and CondAnyOf by using `&&` and `identical()`.
Targets issue #261
