### PR TITLE
fix return type of qunif for ParamInt

### DIFF
--- a/R/ParamInt.R
+++ b/R/ParamInt.R
@@ -57,6 +57,6 @@ ParamInt = R6Class("ParamInt", inherit = Param,
 
   private = list(
     .check = function(x) checkInt(x, lower = self$lower, upper = self$upper),
-    .qunif = function(x) floor(x * self$nlevels * (1 - 1e-16)) + self$lower # make sure we dont map to upper+1
+    .qunif = function(x) as.integer(floor(x * self$nlevels * (1 - 1e-16)) + self$lower) # make sure we dont map to upper+1
   )
 )

--- a/tests/testthat/test_ParamDbl.R
+++ b/tests/testthat/test_ParamDbl.R
@@ -44,6 +44,7 @@ test_that("qunif", {
     p = ParamDbl$new("x", lower = a, upper = b)
     u = runif(n)
     v1 = p$qunif(u)
+    expect_double(v1, any.missing = FALSE, len = n)
     v2 = runif(n, min = a, max = b)
     e1 = ecdf(v1)
     e2 = ecdf(v2)

--- a/tests/testthat/test_ParamFct.R
+++ b/tests/testthat/test_ParamFct.R
@@ -16,6 +16,7 @@ test_that("qunif", {
     k = p$nlevels
     u = runif(n)
     v1 = p$qunif(u)
+    expect_character(v1, any.missing = FALSE, len = n)
     expect_setequal(unique(v1), p$levels) # check we see all levels
     # check that empirical frequencies are pretty much uniform
     freqs = prop.table(table(v1))

--- a/tests/testthat/test_ParamInt.R
+++ b/tests/testthat/test_ParamInt.R
@@ -36,6 +36,7 @@ test_that("qunif", {
     expect_equal(k, b - a + 1)
     u = runif(n)
     v1 = p$qunif(u)
+    expect_integer(v1, any.missing = FALSE, len = n)
     expect_setequal(unique(v1), a:b) # check we see all levels
     # check that empirical frequencies are pretty much uniform
     freqs = prop.table(table(v1))

--- a/tests/testthat/test_ParamLgl.R
+++ b/tests/testthat/test_ParamLgl.R
@@ -13,6 +13,7 @@ test_that("qunif", {
     p = ParamLgl$new("x")
     u = runif(n)
     v1 = p$qunif(u)
+    expect_logical(v1, any.missing = FALSE, len = n)
     expect_setequal(unique(v1), p$levels) # check we see all levels
     # check that empirical frequencies are pretty much uniform
     freqs = prop.table(table(v1))


### PR DESCRIPTION
* explicitly return `integer`s in `qunif()` of `ParamInt`s
* add tests for checking the return type of `qunif()` for `ParamInt`, `ParamDbl`, `ParamFct` and `ParamLgl`