### PR TITLE
adding params_unid

### DIFF
--- a/R/Param.R
+++ b/R/Param.R
@@ -67,7 +67,7 @@ Param = R6Class("Param",
       # either we are directly feasible, or in special vals, if both are untrue return errmsg from 1st check
       if (inherits(x, "TuneToken")) {
         return(tryCatch({
-          tunetoken_to_ps(x, self)
+          tunetoken_to_ps(x, self, self$id)
           TRUE
         }, error = function(e) paste("tune token invalid:", conditionMessage(e))))
       }

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -395,6 +395,7 @@ ParamSet = R6Class("ParamSet",
       }
       private$.params
     },
+    #' @template field_params_unid
     params_unid = function(rhs) {
       if (!missing(rhs) && !identical(rhs, private$.params)) {
         stop("$params_unid is read-only.")

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -71,7 +71,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       pnames = names(p$params_unid)
       nameclashes = intersect(
         ifelse(p$set_id != "", sprintf("%s.%s", p$set_id, pnames), pnames),
-        pnames
+        names(self$params_unid)
       )
       if (length(nameclashes)) {
         stopf("Adding parameter set would lead to nameclashes: %s", str_collapse(nameclashes))
@@ -109,6 +109,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
         x
       })
     },
+    #' @template field_params_unid
     params_unid = function(v) {
       sets = private$.sets
       names(sets) = map_chr(sets, "set_id")

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -38,17 +38,18 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       named_sets = split_sets$`FALSE`
       setids = map_chr(named_sets, "set_id")
       assert_names(setids, type = "unique")
-      assert_names(unlist(map(nameless_sets, function(x) names(x$params))) %??% character(0), type = "unique")
+      assert_names(unlist(map(nameless_sets, function(x) names(x$params_unid))) %??% character(0), type = "unique")
       if (any(map_lgl(sets, "has_trafo"))) {
         # we need to be able to have a trafo on the collection, not sure how to mix this with individual trafos yet.
         stop("Building a collection out sets, where a ParamSet has a trafo is currently unsupported!")
       }
       private$.sets = sets
       self$set_id = ""
-      dups = duplicated(names(self$params))
+      pnames = names(self$params_unid)
+      dups = duplicated(pnames)
       if (any(dups)) {
         stopf("ParamSetCollection would contain duplicated parameter names: %s",
-          str_collapse(unique(names(self$params)[dups])))
+          str_collapse(unique(pnames[dups])))
       }
     },
 
@@ -60,16 +61,17 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       assert_r6(p, "ParamSet")
       setnames = map_chr(private$.sets, "set_id")
       if (p$set_id == "") {
-        unnamed_set_parnames = map(private$.sets[setnames == ""], function(x) names(x$params))
+        unnamed_set_parnames = map(private$.sets[setnames == ""], function(x) names(x$params_unid))
       } else if (p$set_id %in% setnames) {
         stopf("Setid '%s' already present in collection!", p$set_id)
       }
       if (p$has_trafo) {
         stop("Building a collection out sets, where a ParamSet has a trafo is currently unsupported!")
       }
+      pnames = names(p$params_unid)
       nameclashes = intersect(
-        ifelse(p$set_id != "", sprintf("%s.%s", p$set_id, names(p$params)), names(p$params)),
-        names(self$params)
+        ifelse(p$set_id != "", sprintf("%s.%s", p$set_id, pnames), pnames),
+        pnames
       )
       if (length(nameclashes)) {
         stopf("Adding parameter set would lead to nameclashes: %s", str_collapse(nameclashes))
@@ -100,7 +102,14 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
   active = list(
     #' @template field_params
     params = function(v) {
-
+      ps_all = self$params_unid
+      imap(ps_all, function(x, n) {
+        x = x$clone(deep = TRUE)
+        x$id = n
+        x
+      })
+    },
+    params_unid = function(v) {
       sets = private$.sets
       names(sets) = map_chr(sets, "set_id")
       if (length(sets) == 0L) {
@@ -108,13 +117,11 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       }
       private$.params = named_list()
       # clone each param into new params-list and prefix id
-      ps_all = lapply(sets, function(s) s$clone(deep = TRUE)$params)
+      ps_all = lapply(sets, function(s) s$params_unid)
       ps_all = unlist(ps_all, recursive = FALSE)
       if (!length(ps_all)) ps_all = named_list()
-      imap(ps_all, function(x, n) x$id = n)
       ps_all
     },
-
     #' @template field_deps
     deps = function(v) {
       d_all = lapply(private$.sets, function(s) {
@@ -141,7 +148,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
 
         for (s in sets) {
           # retrieve sublist for each set, then assign it in set (after removing prefix)
-          psids = names(s$params)
+          psids = names(s$params_unid)
           if (s$set_id != "") {
             psids = sprintf("%s.%s", s$set_id, psids)
           }

--- a/man-roxygen/field_params_unid.R
+++ b/man-roxygen/field_params_unid.R
@@ -1,0 +1,5 @@
+#' @field params_unid (named `list()`)\cr
+#' List of [Param], named with their true ID. However,
+#' this field has the [Param]'s `$id` value set to a
+#' potentially invalid value. This active binding should
+#' only be used internally.

--- a/man/ParamSet.Rd
+++ b/man/ParamSet.Rd
@@ -62,6 +62,12 @@ Default is \code{TRUE}, only switch this off if you know what you are doing.}
 \item{\code{params}}{(named \code{list()})\cr
 List of \link{Param}, named with their respective ID.}
 
+\item{\code{params_unid}}{(named \code{list()})\cr
+List of \link{Param}, named with their true ID. However,
+this field has the \link{Param}'s \verb{$id} value set to a
+potentially invalid value. This active binding should
+only be used internally.}
+
 \item{\code{deps}}{(\code{\link[data.table:data.table]{data.table::data.table()}})\cr
 Table has cols \code{id} (\code{character(1)}) and \code{on} (\code{character(1)}) and \code{cond} (\link{Condition}).
 Lists all (direct) dependency parents of a param, through parameter IDs.

--- a/man/ParamSetCollection.Rd
+++ b/man/ParamSetCollection.Rd
@@ -37,6 +37,12 @@ If you call \code{deps} on the collection, you are returned a complete table of 
 \item{\code{params}}{(named \code{list()})\cr
 List of \link{Param}, named with their respective ID.}
 
+\item{\code{params_unid}}{(named \code{list()})\cr
+List of \link{Param}, named with their true ID. However,
+this field has the \link{Param}'s \verb{$id} value set to a
+potentially invalid value. This active binding should
+only be used internally.}
+
 \item{\code{deps}}{(\code{\link[data.table:data.table]{data.table::data.table()}})\cr
 Table has cols \code{id} (\code{character(1)}) and \code{on} (\code{character(1)}) and \code{cond} (\link{Condition}).
 Lists all (direct) dependency parents of a param, through parameter IDs.


### PR DESCRIPTION
Performance improvement for miesmuschel, mlr3pipelines and possibly others.

Whenever the `$params` active binding is called, ParamSetCollection (PSC) creates a clone of every `Param` that it contains. This is *only* done because the `Param`'s `$id`, when returned from a PSC, is different from when returned from its sub-ParamSets. However, the `$id` slot is hardly ever used, so we can avoid a lot of cloning if there is a "`$params`-but-without-the-id" active binding that can be used instead. This active binding would just return the uncloned `Param`s.

Since `$params` gets accessed quite a lot this can make quite some difference, more than a factor of 2 for miesmuschel in some cases.

I plan to add some documentation about how `params_unid` is for internal use mostly. Would be happy about other comments.