### PR TITLE
logscale and optional tunetoken args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # paradox 0.7.0-9000
 
 * `Sampler1D` also accept `ParamSet`s with one `Param` now.
+* `to_tune`, `p_dbl`, and `p_int` accept `logscale` argument for tuning on a
+  logarithmic scale.
+* `to_tune` can be called with only `lower` or only `upper` now and will infer
+  the other bound if possible.
 
 # paradox 0.7.0
 

--- a/R/ParamDbl.R
+++ b/R/ParamDbl.R
@@ -14,6 +14,7 @@
 #' @template param_special_vals
 #' @template param_default
 #' @template param_tags
+#' @template param_tolerance
 #'
 #' @family Params
 #' @include Param.R
@@ -35,9 +36,6 @@ ParamDbl = R6Class("ParamDbl", inherit = Param,
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
-    #' @param tolerance (`numeric(1)`)\cr
-    #'   Initializes the `$tolerance` field that determines the
-    #    tolerance of the `lower` and `upper` values.
     initialize = function(id, lower = -Inf, upper = Inf, special_vals = list(), default = NO_DEF, tags = character(), tolerance = sqrt(.Machine$double.eps)) {
       self$lower = assert_number(lower)
       self$upper = assert_number(upper)

--- a/R/domain.R
+++ b/R/domain.R
@@ -26,6 +26,7 @@
 #' @template param_default
 #' @template param_tags
 #' @template param_custom_check
+#' @template param_tolerance
 #' @param trafo (`function`)\cr
 #'   Single argument function performing the transformation of a parameter. When the `Domain` is used to construct a
 #'   [`ParamSet`], this transformation will be applied to the corresponding parameter as part of the `$trafo` function.\cr

--- a/man-roxygen/param_tolerance.R
+++ b/man-roxygen/param_tolerance.R
@@ -1,0 +1,3 @@
+#' @param tolerance (`numeric(1)`)\cr
+#'   Initializes the `$tolerance` field that determines the
+#    tolerance of the `lower` and `upper` values.

--- a/man/Domain.Rd
+++ b/man/Domain.Rd
@@ -16,7 +16,8 @@ p_int(
   default = NO_DEF,
   tags = character(),
   depends = NULL,
-  trafo = NULL
+  trafo = NULL,
+  logscale = FALSE
 )
 
 p_dbl(
@@ -25,8 +26,10 @@ p_dbl(
   special_vals = list(),
   default = NO_DEF,
   tags = character(),
+  tolerance = sqrt(.Machine$double.eps),
   depends = NULL,
-  trafo = NULL
+  trafo = NULL,
+  logscale = FALSE
 )
 
 p_uty(
@@ -94,7 +97,31 @@ dependencies according to \verb{ParamSet$add_dep(on = "<Param>", cond = CondEqua
 
 \item{trafo}{(\code{function})\cr
 Single argument function performing the transformation of a parameter. When the \code{Domain} is used to construct a
-\code{\link{ParamSet}}, this transformation will be applied to the corresponding parameter as part of the \verb{$trafo} function.}
+\code{\link{ParamSet}}, this transformation will be applied to the corresponding parameter as part of the \verb{$trafo} function.\cr
+Note that the trafo is \emph{not} inherited by \code{\link{TuneToken}}s! Defining a parameter
+with e.g. \code{p_dbl(..., trafo = ...)} will \emph{not} automatically give the \code{to_tune()} assigned to it a transformation.
+\code{trafo} only makes sense for \code{\link{ParamSet}}s that get used as search spaces for optimization or tuning, it is not useful when
+defining domains or hyperparameter ranges of learning algorithms, because these do not use trafos.}
+
+\item{logscale}{(\code{logical(1)})\cr
+Put numeric domains on a log scale. Default \code{FALSE}. Log-scale \code{Domain}s represent parameter ranges where lower and upper bounds
+are logarithmized, and where a \code{trafo} is added that exponentiates sampled values to the original scale. This is
+\emph{not} the same as setting \code{trafo = exp}, because \code{logscale = TRUE} will handle parameter bounds internally:
+a \code{p_dbl(1, 10, logscale = TRUE)} results in a \code{\link{ParamDbl}} that has lower bound \code{0}, upper bound \code{log(10)},
+and uses \code{exp} transformation on these. Therefore, the given bounds represent the bounds \emph{after} the transformation.
+(see examples).\cr
+\code{p_int()} with \code{logscale = TRUE} results in a \code{\link{ParamDbl}}, not a \code{\link{ParamInt}}, but with bounds \code{log(max(lower, 0.5))} ...
+\code{log(upper + 1)} and a trafo similar to "\code{as.integer(exp(x))}" (with additional bounds correction). The lower bound
+is lifted to \code{0.5} if \code{lower} 0 to handle the \code{lower == 0} case. The upper bound is increased to \code{log(upper + 1)}
+because the trafo would otherwise almost never generate a value of \code{upper}.\cr
+When \code{logscale} is \code{TRUE}, then upper bounds may be infinite, but lower bounds should be greater than 0 for \code{p_dbl()}
+or greater or equal 0 for \code{p_int()}.\cr
+Note that "logscale" is \emph{not} inherited by \code{\link{TuneToken}}s! Defining a parameter
+with \verb{p_dbl(... logscale = TRUE)} will \emph{not} automatically give the \code{to_tune()} assigned to it log-scale. \code{logscale}
+only makes sense for \code{\link{ParamSet}}s that get used as search spaces for optimization or tuning, it is not useful when
+defining domains or hyperparameter ranges of learning algorithms, because these do not use trafos.\cr
+\code{logscale} happens on a natural (\verb{e == 2.718282...}) basis. Be aware that using a different base (\code{log10()}/\verb{10^},
+\code{log2()}/\verb{2^}) is completely equivalent and does not change the values being sampled after transformation.}
 
 \item{custom_check}{(\verb{function()})\cr
 Custom function to check the feasibility.
@@ -151,6 +178,30 @@ params$trafo(list(
   factor_param = "c",
   factor_param_with_implicit_trafo = "c"
 ))
+
+# logscale:
+params = ps(x = p_dbl(1, 100, logscale = TRUE))
+
+# The ParamSet has bounds log(1) .. log(100):
+print(params)
+
+# When generating a equidistant grid, it is equidistant within log values
+grid = generate_design_grid(params, 3)
+print(grid)
+
+# But the values are on a log scale with desired bounds after trafo
+print(grid$transpose())
+
+# Integer parameters with logscale are `ParamDbl`s pre-trafo
+params = ps(x = p_int(0, 10, logscale = TRUE))
+print(params)
+
+grid = generate_design_grid(params, 4)
+print(grid)
+
+# ... but get transformed to integers.
+print(grid$transpose())
+
 }
 \seealso{
 Other ParamSet construction helpers: 

--- a/man/Domain.Rd
+++ b/man/Domain.Rd
@@ -123,6 +123,9 @@ defining domains or hyperparameter ranges of learning algorithms, because these 
 \code{logscale} happens on a natural (\verb{e == 2.718282...}) basis. Be aware that using a different base (\code{log10()}/\verb{10^},
 \code{log2()}/\verb{2^}) is completely equivalent and does not change the values being sampled after transformation.}
 
+\item{tolerance}{(\code{numeric(1)})\cr
+Initializes the \verb{$tolerance} field that determines the}
+
 \item{custom_check}{(\verb{function()})\cr
 Custom function to check the feasibility.
 Function which checks the input.

--- a/man/to_tune.Rd
+++ b/man/to_tune.Rd
@@ -29,9 +29,16 @@ can be constructed via the \code{to_tune()} function in one of several ways:
 \itemize{
 \item \strong{\code{to_tune()}}: Indicates a parameter should be tuned over its entire range. Only applies to finite parameters
 (i.e. discrete or bounded numeric parameters)
-\item \strong{\code{to_tune(lower, upper)}}: Indicates a numeric parameter should be tuned in the inclusive interval spanning
-\code{lower} to \code{upper}. Depending on the parameter, integer (if it is a \code{\link{ParamInt}}) or real values (if it is a
-\code{\link{ParamDbl}}) are used.
+\item \strong{\code{to_tune(lower, upper, logscale)}}: Indicates a numeric parameter should be tuned in the inclusive interval spanning
+\code{lower} to \code{upper}, possibly on a log scale if \code{logscale} is se to \code{TRUE}. All parameters are optional, and the
+parameter's own lower / upper bounds are used without log scale, by default. Depending on the parameter,
+integer (if it is a \code{\link{ParamInt}}) or real values (if it is a \code{\link{ParamDbl}}) are used.\cr
+\code{lower}, \code{upper}, and \code{logscale} can be given by position, except when only one of them is given, in which case
+it must be named to disambiguate from the following cases.\cr
+When \code{logscale} is \code{TRUE}, then a \code{trafo} is generated automatically that transforms to the given bounds. The
+bounds are log()'d pre-trafo (see examples). See the \code{logscale} argument of \code{\link{Domain}} functions for more info.\cr
+Note that "logscale" is \emph{not} inherited from the \code{\link{Param}} that the \code{TuneToken} belongs to! Defining a parameter
+with \verb{p_dbl(... logscale = TRUE)} will \emph{not} automatically give the \code{to_tune()} assigned to it log-scale.
 \item \strong{\code{to_tune(levels)}}: Indicates a parameter should be tuned through the given discrete values. \code{levels} can be any
 named or unnamed atomic vector or list (although in the unnamed case it must be possible to construct a
 corresponding \code{character} vector with distinct values using \code{as.character}).
@@ -53,6 +60,7 @@ params = ParamSet$new(list(
   ParamInt$new("int_unbounded"),
   ParamDbl$new("dbl", 0, 10),
   ParamDbl$new("dbl_unbounded"),
+  ParamDbl$new("dbl_bounded_below", lower = 1),
   ParamFct$new("fct", c("a", "b", "c")),
   ParamUty$new("uty1"),
   ParamUty$new("uty2"),
@@ -69,10 +77,11 @@ params$values = list(
   # tune over 2..7:
   int_unbounded = to_tune(2, 7),
 
-  # tune on a log scale in range 1..10:
-  # (you have to make sure exp(log(x)) does not overstep boundaries because
-  # of rounding errors; unfortunately paradox is your enemy here.)
-  dbl = to_tune(p_dbl(log(1 + 1e-10), log(10 - 1e-10), trafo = exp)),
+  # tune on a log scale in range 1..10;
+  # recognize upper bound of 10 automatically, but restrict lower bound to 1:
+  dbl = to_tune(lower = 1, logscale = TRUE),
+  ## This is equivalent to the following:
+  # dbl = to_tune(p_dbl(log(1), log(10), trafo = exp)),
 
   # nothing keeps us from tuning a dbl over integer values
   dbl_unbounded = to_tune(p_int(1, 10)),
@@ -116,6 +125,21 @@ params$values$uty3 = 8
 params$values$uty2 = to_tune(c(2, 4, 8))
 
 print(params$search_space())
+
+# Notice how `logscale` applies `log()` to lower and upper bound pre-trafo:
+params = ParamSet$new(list(ParamDbl$new("x")))
+
+params$values$x = to_tune(1, 100, logscale = TRUE)
+
+print(params$search_space())
+
+grid = generate_design_grid(params$search_space(), 3)
+
+# The grid is equidistant within log-bounds pre-trafo:
+print(grid)
+
+# But the values are on a log scale scale with desired bounds after trafo:
+print(grid$transpose())
 
 }
 \seealso{

--- a/tests/testthat/test_domain.R
+++ b/tests/testthat/test_domain.R
@@ -238,3 +238,56 @@ test_that("trafos in domains", {
   })$trafo(list(x = 2, y = "gamma", z = 4)), list(x = exp(1), y = 2 * sqrt(3), z = 4, n = 1))
 
 })
+
+test_that("logscale in domains", {
+
+  expect_error(p_dbl(trafo = exp, logscale = TRUE), "When a trafo is given then logscale must be FALSE")
+  expect_error(p_int(trafo = exp, logscale = TRUE), "When a trafo is given then logscale must be FALSE")
+
+  expect_error(p_int(lower = 1, upper = 2.5, logscale = TRUE), "failed.*integer.*value.*not.*double")
+
+  expect_error(p_int(lower = -1, logscale = TRUE), "When logscale is TRUE then lower bound must be greater or equal 0")
+  expect_error(p_dbl(lower = 0, logscale = TRUE), "When logscale is TRUE then lower bound must be strictly greater than 0")
+  expect_error(p_int(logscale = TRUE), "When logscale is TRUE then lower bound must be greater or equal 0")
+  expect_error(p_dbl(logscale = TRUE), "When logscale is TRUE then lower bound must be strictly greater than 0")
+
+  p = ps(x = p_dbl(lower = 1, logscale = TRUE), y = p_int(lower = 1, logscale = TRUE))
+  expect_equal(p$lower, c(x = 0, y = 0))
+  expect_equal(p$upper, c(x = Inf, y = Inf))
+  expect_equal(p$trafo(list(x = 0, y = log(1.5))), list(x = 1, y = 1))
+  expect_equal(p$trafo(list(x = 0, y = log(0.001))), list(x = 1, y = 1))
+  expect_equal(p$trafo(list(x = log(10), y = log(20.5))), list(x = 10, y = 20))
+
+  p = ps(x = p_dbl(lower = 1, upper = 10, logscale = TRUE), y = p_int(lower = 0, upper = 10, logscale = TRUE))
+
+  expect_equal(p$lower, c(x = 0, y = log(.5)))
+  expect_equal(p$upper, c(x = log(10), y = log(11)))
+
+  expect_equal(p$trafo(list(x = 0, y = log(1.5))), list(x = 1, y = 1))
+  expect_equal(p$trafo(list(x = log(10), y = log(11))), list(x = 10, y = 10))
+
+  expect_equal(p$trafo(list(x = log(10), y = log(20))), list(x = 10, y = 10))
+  expect_equal(p$trafo(list(x = log(10), y = log(9.99))), list(x = 10, y = 9))
+
+  expect_equal(p$trafo(list(x = log(10), y = log(1.5))), list(x = 10, y = 1))
+
+  expect_equal(p$trafo(list(x = log(10), y = log(0.5))), list(x = 10, y = 0))
+
+  expect_equal(p$trafo(list(x = log(10), y = log(0.0001))), list(x = 10, y = 0))
+
+  expect_output(print(p_dbl(lower = 1, upper = 10, logscale = TRUE)), "^p_dbl\\(lower = 1, upper = 10, logscale = TRUE\\)$")
+  expect_output(print(p_dbl(lower = 1, logscale = TRUE)), "^p_dbl\\(lower = 1, logscale = TRUE\\)$")
+  expect_output(print(p_int(lower = 0, upper = 10, logscale = TRUE)), "^p_int\\(lower = 0, upper = 10, logscale = TRUE\\)$")
+  expect_output(print(p_int(lower = 0, logscale = TRUE)), "^p_int\\(lower = 0, logscale = TRUE\\)$")
+
+  expect_output(print(p_int(lower = 0, logscale = FALSE)), "^p_int\\(lower = 0, logscale = FALSE\\)$")
+
+  params = ps(x = p_dbl(1, 100, logscale = TRUE))
+  grid = generate_design_grid(params, 3)
+  expect_equal(grid$transpose(), list(list(x = 1), list(x = 10), list(x = 100)))
+
+  params = ps(x = p_int(0, 10, logscale = TRUE))
+  grid = generate_design_grid(params, 4)
+  expect_equal(grid$transpose(), list(list(x = 0), list(x = 1), list(x = 3), list(x = 10)))
+
+})


### PR DESCRIPTION
Add the `logscale` argument to `p_dbl()`, and `p_int()`:
```r
p <- ps(x = p_dbl(1, 100, logscale = TRUE))
print(p)
#> <ParamSet>
#>    id    class lower   upper levels        default value
#> 1:  x ParamDbl     0 4.60517        <NoDefault[3]>      
#> Trafo is set.
print(generate_design_grid(p, 3)$transpose())
#> [[1]]
#> [[1]]$x
#> [1] 1
#> 
#> 
#> [[2]]
#> [[2]]$x
#> [1] 10
#> 
#> 
#> [[3]]
#> [[3]]$x
#> [1] 100
#> 
#> 
p2 <- ps(x = p_int(0, 10, logscale = TRUE))
print(p2)
#> <ParamSet>
#>    id    class      lower    upper levels        default value
#> 1:  x ParamDbl -0.6931472 2.397895        <NoDefault[3]>      
#> Trafo is set.
print(generate_design_grid(p2, 4)$transpose())
#> [[1]]
#> [[1]]$x
#> [1] 0
#> 
#> 
#> [[2]]
#> [[2]]$x
#> [1] 1
#> 
#> 
#> [[3]]
#> [[3]]$x
#> [1] 3
#> 
#> 
#> [[4]]
#> [[4]]$x
#> [1] 10
#> 
#> 
```

Add `logscale` argument to `to_tune()`:
```r
svm <- lrn("classif.svm")
svm$param_set$values$cost = to_tune(.001, 1000, logscale = TRUE)
print(svm$param_set$search_space())
#> <ParamSet>
#>      id    class     lower    upper levels        default value
#> 1: cost ParamDbl -6.907755 6.907755        <NoDefault[3]>      
#> Trafo is set.
print(generate_design_grid(svm$param_set$search_space(), 4)$transpose())
#> [[1]]
#> [[1]]$cost
#> [1] 0.001
#> 
#> 
#> [[2]]
#> [[2]]$cost
#> [1] 0.1
#> 
#> 
#> [[3]]
#> [[3]]$cost
#> [1] 10
#> 
#> 
#> [[4]]
#> [[4]]$cost
#> [1] 1000
#> 
#>
```

Infer use partial bounds in `to_tune()` (this wasn't possible before):
```r
p3 <- ps(x = p_dbl(lower = 0))
p3$values$x = to_tune(upper = 10)
print(p3$search_space())
#> <ParamSet>
#>    id    class lower upper levels        default value
#> 1:  x ParamDbl     0    10        <NoDefault[3]>      
```