### PR TITLE
domain constructors accept quoted dependency

### DIFF
--- a/R/domain.R
+++ b/R/domain.R
@@ -179,6 +179,9 @@ parse_depends = function(depends_expr, evalenv) {
   throw = function(msg = NULL) stopf("Requirement '%s' is broken%s", deparse1(depends_expr), if (!is.null(msg)) sprintf(":\n%s", msg) else "")
 
   if (!is.language(depends_expr)) throw()
+  if (identical(depends_expr[[1]], quote(quote))) {
+    depends_expr = depends_expr[[2]]
+  }
   if (is.expression(depends_expr)) {
     if (length(depends_expr) != 1) {
       throw("given 'expression' objects must have length 1.")

--- a/tests/testthat/test_domain.R
+++ b/tests/testthat/test_domain.R
@@ -99,6 +99,13 @@ test_that("requirements in domains", {
       y = p_dbl(depends = x == 1)
     ), simpleps)
 
+  # quote() is accepted
+  expect_equal(
+    ps(
+      x = p_int(),
+      y = p_dbl(depends = quote(x == 1))
+    ), simpleps)
+
   # using a expression variable
   reqquote = quote(x == 1)
   expect_equal(


### PR DESCRIPTION
Useful for package development, where the static type checker complains otherwise.