### PR TITLE
Param init delay

### DIFF
--- a/R/NoDefault.R
+++ b/R/NoDefault.R
@@ -22,4 +22,4 @@ NoDefault = R6Class("NoDefault",
 
 #' @export
 NO_DEF = NoDefault$new() # nolint
-is_nodefault = function(x) test_r6(x, "NoDefault")
+is_nodefault = function(x) inherits(x, "NoDefault")

--- a/R/ParamFct.R
+++ b/R/ParamFct.R
@@ -17,9 +17,6 @@
 ParamFct = R6Class("ParamFct", inherit = Param,
   public = list(
 
-    #' @template field_levels
-    levels = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
@@ -27,18 +24,20 @@ ParamFct = R6Class("ParamFct", inherit = Param,
     #'   Set of allowed levels.
     initialize = function(id, levels, special_vals = list(), default = NO_DEF, tags = character()) {
       assert_character(levels, any.missing = FALSE, unique = TRUE)
-      self$levels = levels
+      private$.levels = levels
       super$initialize(id, special_vals = special_vals, default = default, tags = tags)
     }
   ),
 
   active = list(
+    #' @template field_levels
+    levels = function() private$.levels,
     #' @template field_lower
     lower = function() NA_real_,
     #' @template field_upper
     upper = function() NA_real_,
     #' @template field_nlevels
-    nlevels = function() length(self$levels),
+    nlevels = function() length(private$.levels),
     #' @template field_is_bounded
     is_bounded = function() TRUE,
     #' @template field_storage_type
@@ -46,11 +45,13 @@ ParamFct = R6Class("ParamFct", inherit = Param,
   ),
 
   private = list(
-    .check = function(x) check_choice(x, choices = self$levels),
+    .check = function(x) check_choice(x, choices = private$.levels),
 
     .qunif = function(x) {
       z = floor(x * self$nlevels * (1 - 1e-16)) + 1 # make sure we dont map to upper+1
-      self$levels[z]
-    }
+      private$.levels[z]
+    },
+
+    .levels = NULL
   )
 )

--- a/R/ParamInt.R
+++ b/R/ParamInt.R
@@ -20,24 +20,18 @@
 #' ParamInt$new("count", lower = 0, upper = 10, default = 1)
 ParamInt = R6Class("ParamInt", inherit = Param,
   public = list(
-    #' @template field_lower
-    lower = NULL,
-
-    #' @template field_upper
-    upper = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function(id, lower = -Inf, upper = Inf, special_vals = list(), default = NO_DEF, tags = character()) {
       if (isTRUE(is.infinite(lower))) {
-        self$lower = lower
+        private$.lower = lower
       } else {
-        self$lower = assert_int(lower)
+        private$.lower = assert_int(lower)
       }
       if (isTRUE(is.infinite(upper))) {
-        self$upper = upper
+        private$.upper = upper
       } else {
-        self$upper = assert_int(upper)
+        private$.upper = assert_int(upper)
       }
       assert_true(lower <= upper)
       super$initialize(id, special_vals = special_vals, default = default, tags = tags)
@@ -53,18 +47,24 @@ ParamInt = R6Class("ParamInt", inherit = Param,
   ),
 
   active = list(
+    #' @template field_lower
+    lower = function() private$.lower,
+    #' @template field_upper
+    upper = function() private$.upper,
     #' @template field_levels
     levels = function() NULL,
     #' @template field_nlevels
-    nlevels = function() (self$upper - self$lower) + 1L,
+    nlevels = function() (private$.upper - private$.lower) + 1L,
     #' @template field_is_bounded
-    is_bounded = function() is.finite(self$lower) && is.finite(self$upper),
+    is_bounded = function() is.finite(private$.lower) && is.finite(private$.upper),
     #' @template field_storage_type
     storage_type = function() "integer"
   ),
 
   private = list(
-    .check = function(x) checkInt(x, lower = self$lower, upper = self$upper, tol = 1e-300),
-    .qunif = function(x) as.integer(floor(x * self$nlevels * (1 - 1e-16)) + self$lower) # make sure we dont map to upper+1
+    .check = function(x) checkInt(x, lower = private$.lower, upper = private$.upper, tol = 1e-300),
+    .qunif = function(x) as.integer(floor(x * self$nlevels * (1 - 1e-16)) + private$.lower), # make sure we dont map to upper+1
+    .lower = NULL,
+    .upper = NULL
   )
 )

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -702,7 +702,9 @@ ParamSet = R6Class("ParamSet",
 
 #' @export
 as.data.table.ParamSet = function(x, ...) { # nolint
-  map_dtr(x$params, as.data.table)
+  punid = x$params_unid
+  id = NULL
+  map_dtr(punid, as.data.table)[, id := names(punid)][]
 }
 
 #' @export

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -125,7 +125,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       # as the original is NULL).
       changed = as.logical(imap(punid, function(x, n) !identical(private$.params_cloned[[n]], x)))
 
-      if (any(changed)) {
+      if (any(changed) || length(punid) != length(private$.params_cloned)) {  # if there was a strict subset operation we wouldn't notice it otherwise
         changed_names = truenames[changed]
         private$.params = c(private$.params[setdiff(names(private$.params), changed_names)],  # don't regenerate Params that were not changed.
           sapply(changed_names, function(u) {

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -29,20 +29,26 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
     #' @param sets (`list()` of [ParamSet])\cr
-    #'   Parameter objects are cloned.
-    initialize = function(sets) {
+    #'   ParamSet objects are not cloned.
+    #' @param ignore_ids (`logical(1)`)\cr
+    #'   Ignore `$set_id` slots of `sets` and instead use the names instead.
+    #'   When this is `TRUE`, then `sets` should be named when id prefixes are desired.
+    #'   This can be used to create a `ParamSetCollection` with changed [`ParamSet`] `set_id`s
+    #'   without having to clone said [`ParamSet`]s. However, when underlying [`ParamSet`]s'
+    #'   `$set_id`s change, then this change is no longer reflected in the ParamSetCollection.
+    #'   Default `FALSE`.
+    initialize = function(sets, ignore_ids = FALSE) {
 
       assert_list(sets, types = "ParamSet")
-      split_sets = split(sets, map_lgl(sets, function(x) x$set_id == ""))
+      if (!ignore_ids) {
+        names(sets) = map(sets, "set_id")
+      }
+      split_sets = split(sets, names(sets) == "")
       nameless_sets = split_sets$`TRUE`
       named_sets = split_sets$`FALSE`
-      setids = map_chr(named_sets, "set_id")
-      assert_names(setids, type = "unique")
+      assert_names(names2(named_sets), type = "strict")
       assert_names(unlist(map(nameless_sets, function(x) names(x$params_unid))) %??% character(0), type = "unique")
-      if (any(map_lgl(sets, "has_trafo"))) {
-        # we need to be able to have a trafo on the collection, not sure how to mix this with individual trafos yet.
-        stop("Building a collection out sets, where a ParamSet has a trafo is currently unsupported!")
-      }
+      if (!ignore_ids) sets = unname(sets)  # when private$.sets is unnamed, then the set_ids are used.
       private$.sets = sets
       self$set_id = ""
       pnames = names(self$params_unid)
@@ -59,7 +65,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     #' @param p ([ParamSet]).
     add = function(p) {
       assert_r6(p, "ParamSet")
-      setnames = map_chr(private$.sets, "set_id")
+      setnames = names(private$.sets) %??% map_chr(private$.sets, "set_id")
       if (p$set_id == "") {
         unnamed_set_parnames = map(private$.sets[setnames == ""], function(x) names(x$params_unid))
       } else if (p$set_id %in% setnames) {
@@ -76,7 +82,12 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       if (length(nameclashes)) {
         stopf("Adding parameter set would lead to nameclashes: %s", str_collapse(nameclashes))
       }
-      private$.sets = c(private$.sets, list(p))
+      set_addition = list(p)
+      if (!is.null(names(private$.sets))) {
+        # ignoring the other ParamSet's set_id in favor of names(private$.sets), so add the name here as well.
+        names(set_addition) = p$set_id
+      }
+      private$.sets = c(private$.sets, set_addition)
       invisible(self)
     },
 
@@ -85,7 +96,7 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     #'
     #' @param ids (`character()`).
     remove_sets = function(ids) {
-      setnames = map_chr(private$.sets, "set_id")
+      setnames = names(private$.sets) %??% map_chr(private$.sets, "set_id")
       assert_subset(ids, setnames)
       private$.sets[setnames %in% ids] = NULL
       invisible(self)
@@ -101,22 +112,41 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
 
   active = list(
     #' @template field_params
-    params = function(v) {
-      ps_all = self$params_unid
-      imap(ps_all, function(x, n) {
-        x = x$clone(deep = TRUE)
-        x$id = n
-        x
-      })
+    params = function(rhs) {
+      if (!missing(rhs) && !identical(rhs, private$.params)) {
+        stop("$params is read-only.")
+      }
+      # clone on-demand, whenever underlying class changed
+      punid = self$params_unid
+      truenames = names(punid)
+
+      # 'changed' can be either because an underlying ParamSet's $params changed though $add or so,
+      # or because we are calling $params for the first time (in which case all are 'changed'
+      # as the original is NULL).
+      changed = as.logical(imap(punid, function(x, n) !identical(private$.params_cloned[[n]], x)))
+
+      if (any(changed)) {
+        changed_names = truenames[changed]
+        private$.params = c(private$.params[setdiff(names(private$.params), changed_names)],  # don't regenerate Params that were not changed.
+          sapply(changed_names, function(u) {
+            p = punid[[u]]$clone(deep = TRUE)
+            p$id = u
+            p
+          }, simplify = FALSE)
+        )[truenames]
+      }
+      private$.params_cloned = punid
+      private$.params
     },
     #' @template field_params_unid
     params_unid = function(v) {
       sets = private$.sets
-      names(sets) = map_chr(sets, "set_id")
+      if (is.null(names(sets))) {
+        names(sets) = map(private$.sets, "set_id")
+      }
       if (length(sets) == 0L) {
         return(named_list())
       }
-      private$.params = named_list()
       # clone each param into new params-list and prefix id
       ps_all = lapply(sets, function(s) s$params_unid)
       ps_all = unlist(ps_all, recursive = FALSE)
@@ -125,12 +155,16 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     },
     #' @template field_deps
     deps = function(v) {
-      d_all = lapply(private$.sets, function(s) {
+      sets = private$.sets
+      if (is.null(names(sets))) {
+        names(sets) = map(private$.sets, "set_id")
+      }
+      d_all = imap(sets, function(s, id) {
         # copy all deps and rename ids to prefixed versions
         dd = copy(s$deps)
         ids_old = s$ids()
-        if (s$set_id != "" && nrow(dd)) {
-          ids_new = sprintf("%s.%s", s$set_id, ids_old)
+        if (id != "" && nrow(dd)) {
+          ids_new = sprintf("%s.%s", id, ids_old)
           dd$id = map_values(dd$id, ids_old, ids_new)
           dd$on = map_values(dd$on, ids_old, ids_new)
         }
@@ -142,20 +176,24 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     #' @template field_values
     values = function(xs) {
       sets = private$.sets
-      names(sets) = map_chr(sets, "set_id")
+      if (is.null(names(sets))) {
+        names(sets) = map(private$.sets, "set_id")
+      }
       if (!missing(xs)) {
         assert_list(xs)
         self$assert(xs) # make sure everything is valid and feasible
 
-        for (s in sets) {
+        for (i in seq_along(sets)) {
+          s = sets[[i]]
+          sid = names(sets)[[i]]
           # retrieve sublist for each set, then assign it in set (after removing prefix)
           psids = names(s$params_unid)
-          if (s$set_id != "") {
-            psids = sprintf("%s.%s", s$set_id, psids)
+          if (sid != "") {
+            psids = sprintf("%s.%s", sid, psids)
           }
           pv = xs[intersect(psids, names(xs))]
-          if (s$set_id != "") {
-            names(pv) = substr(names(pv), nchar(s$set_id) + 2, nchar(names(pv)))
+          if (sid != "") {
+            names(pv) = substr(names(pv), nchar(sid) + 2, nchar(names(pv)))
           }
           s$values = pv
         }
@@ -168,6 +206,22 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
   ),
 
   private = list(
-    .sets = NULL
+    .sets = NULL,
+    .params_cloned = NULL,
+    deep_clone = function(name, value) {
+      switch(name,
+        .params = named_list(),
+        .params_cloned = NULL,
+        .deps = {
+          value = copy(value)
+          value$cond = lapply(value$cond, function(x) x$clone(deep = TRUE))
+          value
+        },
+        .sets = map(value, function(x) {
+          x$clone(deep = TRUE)
+        }),
+        value
+      )
+    }
   )
 )

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -47,7 +47,6 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
       nameless_sets = split_sets$`TRUE`
       named_sets = split_sets$`FALSE`
       assert_names(names2(named_sets), type = "strict")
-      assert_names(unlist(map(nameless_sets, function(x) names(x$params_unid))) %??% character(0), type = "unique")
       if (!ignore_ids) sets = unname(sets)  # when private$.sets is unnamed, then the set_ids are used.
       private$.sets = sets
       self$set_id = ""

--- a/R/ParamUty.R
+++ b/R/ParamUty.R
@@ -15,10 +15,6 @@
 #' ParamUty$new("untyped", default = Inf)
 ParamUty = R6Class("ParamUty", inherit = Param,
   public = list(
-    #' @field custom_check (`function()`)\cr
-    #' Custom function to check the feasibility.
-    custom_check = NULL,
-
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
     #'
@@ -31,15 +27,18 @@ ParamUty = R6Class("ParamUty", inherit = Param,
       # super class calls private$.check, so this must be set BEFORE
       # we initialize the super class
       if (is.null(custom_check)) {
-        self$custom_check = function(x) TRUE
+        private$.custom_check = function(x) TRUE
       } else {
-        self$custom_check = assert_function(custom_check, "x")
+        private$.custom_check = assert_function(custom_check, "x")
       }
       super$initialize(id, special_vals = list(), default = default, tags = tags)
     }
   ),
 
   active = list(
+    #' @field custom_check (`function()`)\cr
+    #' Custom function to check the feasibility.
+    custom_check = function() private$.custom_check,
     #' @template field_lower
     lower = function() NA_real_,
     #' @template field_upper
@@ -55,7 +54,8 @@ ParamUty = R6Class("ParamUty", inherit = Param,
   ),
 
   private = list(
-    .check = function(x) self$custom_check(x),
-    .qunif = function(x) stop("undefined")
+    .check = function(x) private$.custom_check(x),
+    .qunif = function(x) stop("undefined"),
+    .custom_check = NULL
   )
 )

--- a/man-roxygen/field_params_unid.R
+++ b/man-roxygen/field_params_unid.R
@@ -1,5 +1,7 @@
 #' @field params_unid (named `list()`)\cr
 #' List of [Param], named with their true ID. However,
 #' this field has the [Param]'s `$id` value set to a
-#' potentially invalid value. This active binding should
-#' only be used internally.
+#' potentially invalid value, and it is furthermore not
+#' cloned when the `ParamSet` is cloned. This active
+#' binding should be used internally, or to avoid unnecessary
+#' cloning when that becomes a bottleneck.

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -30,7 +30,12 @@ Other Params:
 \describe{
 \item{\code{id}}{(\code{character(1)})\cr
 Identifier of the object.}
-
+}
+\if{html}{\out{</div>}}
+}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
+\describe{
 \item{\code{special_vals}}{(\code{list()})\cr
 Arbitrary special values this parameter is allowed to take.}
 
@@ -39,12 +44,7 @@ Default value.}
 
 \item{\code{tags}}{(\code{character()})\cr
 Arbitrary tags to group and subset parameters.}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
+
 \item{\code{class}}{(\code{character(1)})\cr
 R6 class name. Read-only.}
 
@@ -67,6 +67,7 @@ Is there a default value?}
 \item \href{#method-assert}{\code{Param$assert()}}
 \item \href{#method-test}{\code{Param$test()}}
 \item \href{#method-rep}{\code{Param$rep()}}
+\item \href{#method-with_tags}{\code{Param$with_tags()}}
 \item \href{#method-format}{\code{Param$format()}}
 \item \href{#method-print}{\code{Param$print()}}
 \item \href{#method-qunif}{\code{Param$qunif()}}
@@ -205,7 +206,27 @@ Each parameter is named "[id]\emph{rep}[k]" and gets the additional tag "[id]_re
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-\link{ParamSet}.
+\code{\link{ParamSet}}.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-with_tags"></a>}}
+\if{latex}{\out{\hypertarget{method-with_tags}{}}}
+\subsection{Method \code{with_tags()}}{
+Creates a clone of this parameter with changed \verb{$tags} slot.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Param$with_tags(tags)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{tags}}{(\code{character}) tags of the clone.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+\code{\link{Param}}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/ParamDbl.Rd
+++ b/man/ParamDbl.Rd
@@ -26,8 +26,8 @@ Other Params:
 \section{Super class}{
 \code{\link[paradox:Param]{paradox::Param}} -> \code{ParamDbl}
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{lower}}{(\code{numeric(1)})\cr
 Lower bound.
@@ -40,12 +40,7 @@ Always \code{NA} for \link{ParamFct}, \link{ParamLgl} and \link{ParamUty}.}
 \item{\code{tolerance}}{(\code{numeric(1)})\cr
 tolerance of values to accept beyond \verb{$lower} and \verb{$upper}.
 Used both for relative and absolute tolerance.}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
+
 \item{\code{levels}}{(\code{character()} | \code{NULL})\cr
 Set of allowed levels.
 Always \code{NULL} for \link{ParamDbl}, \link{ParamInt} and \link{ParamUty}.
@@ -90,6 +85,7 @@ Always \code{"list"} for \link{ParamUty}.}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="qunif">}\href{../../paradox/html/Param.html#method-qunif}{\code{paradox::Param$qunif()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="rep">}\href{../../paradox/html/Param.html#method-rep}{\code{paradox::Param$rep()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="test">}\href{../../paradox/html/Param.html#method-test}{\code{paradox::Param$test()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="with_tags">}\href{../../paradox/html/Param.html#method-with_tags}{\code{paradox::Param$with_tags()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/man/ParamFct.Rd
+++ b/man/ParamFct.Rd
@@ -21,19 +21,14 @@ Other Params:
 \section{Super class}{
 \code{\link[paradox:Param]{paradox::Param}} -> \code{ParamFct}
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{levels}}{(\code{character()} | \code{NULL})\cr
 Set of allowed levels.
 Always \code{NULL} for \link{ParamDbl}, \link{ParamInt} and \link{ParamUty}.
 Always \code{c(TRUE, FALSE)} for \link{ParamLgl}.}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
+
 \item{\code{lower}}{(\code{numeric(1)})\cr
 Lower bound.
 Always \code{NA} for \link{ParamFct}, \link{ParamLgl} and \link{ParamUty}.}
@@ -81,6 +76,7 @@ Always \code{"list"} for \link{ParamUty}.}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="qunif">}\href{../../paradox/html/Param.html#method-qunif}{\code{paradox::Param$qunif()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="rep">}\href{../../paradox/html/Param.html#method-rep}{\code{paradox::Param$rep()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="test">}\href{../../paradox/html/Param.html#method-test}{\code{paradox::Param$test()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="with_tags">}\href{../../paradox/html/Param.html#method-with_tags}{\code{paradox::Param$with_tags()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/man/ParamInt.Rd
+++ b/man/ParamInt.Rd
@@ -26,8 +26,8 @@ Other Params:
 \section{Super class}{
 \code{\link[paradox:Param]{paradox::Param}} -> \code{ParamInt}
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+\if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
 \item{\code{lower}}{(\code{numeric(1)})\cr
 Lower bound.
@@ -36,12 +36,7 @@ Always \code{NA} for \link{ParamFct}, \link{ParamLgl} and \link{ParamUty}.}
 \item{\code{upper}}{(\code{numeric(1)})\cr
 Upper bound.
 Always \code{NA} for \link{ParamFct}, \link{ParamLgl} and \link{ParamUty}.}
-}
-\if{html}{\out{</div>}}
-}
-\section{Active bindings}{
-\if{html}{\out{<div class="r6-active-bindings">}}
-\describe{
+
 \item{\code{levels}}{(\code{character()} | \code{NULL})\cr
 Set of allowed levels.
 Always \code{NULL} for \link{ParamDbl}, \link{ParamInt} and \link{ParamUty}.
@@ -86,6 +81,7 @@ Always \code{"list"} for \link{ParamUty}.}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="qunif">}\href{../../paradox/html/Param.html#method-qunif}{\code{paradox::Param$qunif()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="rep">}\href{../../paradox/html/Param.html#method-rep}{\code{paradox::Param$rep()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="test">}\href{../../paradox/html/Param.html#method-test}{\code{paradox::Param$test()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="with_tags">}\href{../../paradox/html/Param.html#method-with_tags}{\code{paradox::Param$with_tags()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/man/ParamLgl.Rd
+++ b/man/ParamLgl.Rd
@@ -76,6 +76,7 @@ Always \code{"list"} for \link{ParamUty}.}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="qunif">}\href{../../paradox/html/Param.html#method-qunif}{\code{paradox::Param$qunif()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="rep">}\href{../../paradox/html/Param.html#method-rep}{\code{paradox::Param$rep()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="test">}\href{../../paradox/html/Param.html#method-test}{\code{paradox::Param$test()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="with_tags">}\href{../../paradox/html/Param.html#method-with_tags}{\code{paradox::Param$with_tags()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/man/ParamSet.Rd
+++ b/man/ParamSet.Rd
@@ -65,8 +65,10 @@ List of \link{Param}, named with their respective ID.}
 \item{\code{params_unid}}{(named \code{list()})\cr
 List of \link{Param}, named with their true ID. However,
 this field has the \link{Param}'s \verb{$id} value set to a
-potentially invalid value. This active binding should
-only be used internally.}
+potentially invalid value, and it is furthermore not
+cloned when the \code{ParamSet} is cloned. This active
+binding should be used internally, or to avoid unnecessary
+cloning when that becomes a bottleneck.}
 
 \item{\code{deps}}{(\code{\link[data.table:data.table]{data.table::data.table()}})\cr
 Table has cols \code{id} (\code{character(1)}) and \code{on} (\code{character(1)}) and \code{cond} (\link{Condition}).
@@ -190,7 +192,7 @@ Has the set parameter dependencies?}
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParamSet$new(params = named_list())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParamSet$new(params = named_list(), ignore_ids = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -198,7 +200,15 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 \describe{
 \item{\code{params}}{(\code{list()})\cr
 List of \link{Param}, named with their respective ID.
-Parameters are cloned.}
+\code{params} are cloned on-demand, so the input does not need
+to be cloned.}
+
+\item{\code{ignore_ids}}{(\code{logical(1)})\cr
+Ignore \verb{$id} slots of \code{params} and instead use the names instead.
+When this is \code{TRUE}, then \code{params} must be named.
+This can be used to create a \code{ParamSet} with certain \code{\link{Param}} \code{id}s
+without having to clone said \code{\link{Param}}s.
+Default \code{FALSE}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -207,7 +217,8 @@ Parameters are cloned.}
 \if{html}{\out{<a id="method-add"></a>}}
 \if{latex}{\out{\hypertarget{method-add}{}}}
 \subsection{Method \code{add()}}{
-Adds a single param or another set to this set, all params are cloned.
+Adds a single param or another set to this set, all params are cloned on-demand,
+so the input does not need to be cloned.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ParamSet$add(p)}\if{html}{\out{</div>}}
 }

--- a/man/ParamSetCollection.Rd
+++ b/man/ParamSetCollection.Rd
@@ -40,8 +40,10 @@ List of \link{Param}, named with their respective ID.}
 \item{\code{params_unid}}{(named \code{list()})\cr
 List of \link{Param}, named with their true ID. However,
 this field has the \link{Param}'s \verb{$id} value set to a
-potentially invalid value. This active binding should
-only be used internally.}
+potentially invalid value, and it is furthermore not
+cloned when the \code{ParamSet} is cloned. This active
+binding should be used internally, or to avoid unnecessary
+cloning when that becomes a bottleneck.}
 
 \item{\code{deps}}{(\code{\link[data.table:data.table]{data.table::data.table()}})\cr
 Table has cols \code{id} (\code{character(1)}) and \code{on} (\code{character(1)}) and \code{cond} (\link{Condition}).
@@ -91,14 +93,22 @@ When you set values, all previously set values will be unset / removed.}
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParamSetCollection$new(sets)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParamSetCollection$new(sets, ignore_ids = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{sets}}{(\code{list()} of \link{ParamSet})\cr
-Parameter objects are cloned.}
+ParamSet objects are not cloned.}
+
+\item{\code{ignore_ids}}{(\code{logical(1)})\cr
+Ignore \verb{$set_id} slots of \code{sets} and instead use the names instead.
+When this is \code{TRUE}, then \code{sets} should be named when id prefixes are desired.
+This can be used to create a \code{ParamSetCollection} with changed \code{\link{ParamSet}} \code{set_id}s
+without having to clone said \code{\link{ParamSet}}s. However, when underlying \code{\link{ParamSet}}s'
+\verb{$set_id}s change, then this change is no longer reflected in the ParamSetCollection.
+Default \code{FALSE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ParamUty.Rd
+++ b/man/ParamUty.Rd
@@ -21,17 +21,12 @@ Other Params:
 \section{Super class}{
 \code{\link[paradox:Param]{paradox::Param}} -> \code{ParamUty}
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{custom_check}}{(\verb{function()})\cr
-Custom function to check the feasibility.}
-}
-\if{html}{\out{</div>}}
-}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
+\item{\code{custom_check}}{(\verb{function()})\cr
+Custom function to check the feasibility.}
+
 \item{\code{lower}}{(\code{numeric(1)})\cr
 Lower bound.
 Always \code{NA} for \link{ParamFct}, \link{ParamLgl} and \link{ParamUty}.}
@@ -84,6 +79,7 @@ Always \code{"list"} for \link{ParamUty}.}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="qunif">}\href{../../paradox/html/Param.html#method-qunif}{\code{paradox::Param$qunif()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="rep">}\href{../../paradox/html/Param.html#method-rep}{\code{paradox::Param$rep()}}\out{</span>}
 \item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="test">}\href{../../paradox/html/Param.html#method-test}{\code{paradox::Param$test()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="paradox" data-topic="Param" data-id="with_tags">}\href{../../paradox/html/Param.html#method-with_tags}{\code{paradox::Param$with_tags()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -145,33 +145,33 @@ test_that("ParamSet$print", {
   }
 })
 
-test_that("ParamSet does a deep copy of params on construction", {
+test_that("ParamSet does a delayed deep copy of params on construction", {
   p = ParamDbl$new("x", lower = 1, upper = 3)
-  ps = ParamSet$new(list(p))
-  p$lower = 2
-  expect_equal(p$lower, 2)
-  expect_equal(ps$lower, c(x = 1))
-  expect_equal(ps$params[["x"]]$lower, 1)
+  ps = ParamSet$new(list(y = p), ignore_ids = TRUE)
+  expect_equal(ps$params_unid, list(y = p))
+  expect_equal(ps$params, list(y = ParamDbl$new("y", lower = 1, upper = 3)))
 })
 
-test_that("ParamSet does a deep copy of param on add", {
+test_that("ParamSet does a delayed deep copy of param on add", {
   p = ParamDbl$new("x", lower = 1, upper = 3)
-  ps = ParamSet$new(list())$add(p)
-  p$lower = 2
-  expect_equal(p$lower, 2)
-  expect_equal(ps$lower, c(x = 1))
-  expect_equal(ps$params[["x"]]$lower, 1)
+  ps = ParamSet$new(list())$add(ParamSet$new(list(y = p), ignore_ids = TRUE))
+  expect_equal(ps$params_unid, list(y = p))
+  expect_equal(ps$params, list(y = ParamDbl$new("y", lower = 1, upper = 3)))
+
 })
 
 test_that("ParamSet$clone can be deep", {
+
   p1 = ParamDbl$new("x", lower = 1, upper = 3)
   p2 = ParamFct$new("y", levels = c("a", "b"))
   ps1 = ParamSet$new(list(p1, p2))
   ps2 = ps1$clone(deep = TRUE)
-  pp = ps2$params[["x"]]
-  pp$lower = 9
-  expect_equal(ps2$lower, c(x = 9, y = NA))
-  expect_equal(ps1$lower, c(x = 1, y = NA))
+
+  p3 = ParamFct$new("z", levels = c("a", "b"))
+  ps2$add(p3)
+
+  expect_equal(ps2$params, list(x = p1, y = p2, z = p3))
+  expect_equal(ps1$params, list(x = p1, y = p2))
 
   # now lets add a dep, see if that gets clones properly
   ps1$add_dep("x", on = "y", CondEqual$new("a"))

--- a/tests/testthat/test_ParamSetCollection.R
+++ b/tests/testthat/test_ParamSetCollection.R
@@ -57,6 +57,12 @@ test_that("ParamSet basic stuff works", {
     expect_equal(x$s2.th_param_int, 99)
   }
 
+  # Generate cached values for comparisons
+  ps1$params
+  ps2$params
+  ps1clone$params
+  ps2clone$params
+
   # ps1 and ps2 should not be changed
   expect_equal(ps1, ps1clone)
   expect_equal(ps2, ps2clone)
@@ -164,6 +170,11 @@ test_that("values", {
   setindex(ps2clone$deps, NULL)
   setindex(ps1$deps, NULL)
   setindex(ps2$deps, NULL)
+
+  ps1$params
+  ps2$params
+  ps1clone$params
+  ps2clone$params
 
   expect_equal(ps1clone, ps1)
   expect_equal(ps2clone, ps2)

--- a/tests/testthat/test_Param_rep.R
+++ b/tests/testthat/test_Param_rep.R
@@ -21,12 +21,3 @@ test_that("rep params work", {
   }
 })
 
-
-test_that("rep params deep copies", {
-  p = ParamDbl$new(id = "x", lower = 1, upper = 3)
-  ps = p$rep(1L)
-  # lets change the first param
-  p$lower = 99
-  expect_equal(p$lower, 99)
-  expect_equal(ps$params[["x_rep_1"]]$lower, 1)
-})

--- a/tests/testthat/test_sampler.R
+++ b/tests/testthat/test_sampler.R
@@ -104,8 +104,16 @@ test_that("we had a bug where creating the joint sampler changed the ps-ref of t
   s1 = Sampler1DCateg$new(p1)
   s2 = Sampler1DUnif$new(p2)
   s = SamplerJointIndep$new(list(s1, s2))
-  expect_equal(s1$param_set, ParamSet$new(list(th_param_fct())))
-  expect_equal(s2$param_set, ParamSet$new(list(th_param_dbl())))
+
+  s1_expected = ParamSet$new(list(th_param_fct()))
+  s1_expected$params
+  s1$param_set$params
+  expect_equal(s1$param_set, s1_expected)
+
+  s2_expected = ParamSet$new(list(th_param_dbl()))
+  s2_expected$params
+  s2$param_set$params
+  expect_equal(s2$param_set, s2_expected)
 })
 
 test_that("Sampler1DRfun with 0 samples (#338)", {


### PR DESCRIPTION
Delay initing / cloning of `Param`s to when it is necessary by:
1. making `Param`s immutable, except for the `id`. If you want a different `Param` you have to create a new one now. This should not be a problem with `to_tune()` etc. I have never had the need to modify a `Param`.
2. using the `$params_unid` slot, which returns `Param`s with the `$id` set to the wrong value (the names of the list identify the actual `id`), which avoids cloning. With this is it possible to have deep hierarchies of `ParamSetCollection`s that just return their leaf `Param`s without having to clone at all.
3. Cloning `Param` on-demand whenever the user accesses `$params`. This basically never happens, except when the user himself actually accesses `$params`, since `$params_unid` carries the same information.

This works with:
- [X] [bbotk](https://github.com/mlr-org/bbotk/pull/134)
- [X] [mlr3tuning](https://github.com/mlr-org/mlr3tuning/pull/296)
- [X] [mlr3](https://github.com/mlr-org/mlr3/pull/621)
- [X] [mlr3pipelines](https://github.com/mlr-org/mlr3pipelines/pull/574)
- [ ] [mlr3gallery](https://github.com/mlr-org/mlr3gallery/pull/94)
- [ ] [mlr3book](https://github.com/mlr-org/mlr3book/pull/228)