### PR TITLE
Improve printing of untyped parameters

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -686,8 +686,12 @@ rd_info.ParamSet = function(ps, descriptions = character(), ...) { # nolint
     params[is.na(description), description := ""]
     setcolorder(params, c("id", "description"))
   }
-
-  set(params, i = which(map_lgl(params$default, inherits, "NoDefault")), j = "default", value = list("-"))
+  is_default = map_lgl(params$default, inherits, "NoDefault")
+  is_uty = params$storage_type == "list"
+  set(params, i = which(is_uty & !is_default), j = "default",
+      value = map(ps$params[!is_default & is_uty], function(x) x$repr))
+  set(params, i = which(is_uty), j = "storage_type", value = list("untyped"))
+  set(params, i = which(is_default), j = "default", value = list("-"))
 
   if (!allMissing(params$lower) || !allMissing(params$upper)) {
     set(params, j = "range", value = pmap_chr(params[, c("lower", "upper"), with = FALSE], rd_format_range))
@@ -699,7 +703,7 @@ rd_info.ParamSet = function(ps, descriptions = character(), ...) { # nolint
   } else {
     set(params, j = "levels", value = map_chr(params$levels, str_collapse, n = 10L))
   }
-
   setnames(params, "storage_type", "type")
   c("", knitr::kable(params, col.names = capitalize(names(params))))
 }
+

--- a/R/ParamUty.R
+++ b/R/ParamUty.R
@@ -18,6 +18,9 @@ ParamUty = R6Class("ParamUty", inherit = Param,
     #' @field custom_check (`function()`)\cr
     #' Custom function to check the feasibility.
     custom_check = NULL,
+    #' @field repr (`character(1)`)\cr
+    #' Custom field for printing the parameter table.
+    repr = NULL,
 
     #' @description
     #' Creates a new instance of this [R6][R6::R6Class] class.
@@ -27,13 +30,21 @@ ParamUty = R6Class("ParamUty", inherit = Param,
     #'   Function which checks the input.
     #'   Must return 'TRUE' if the input is valid and a string with the error message otherwise.
     #'   Defaults to `NULL`, which means that no check is performed.
-    initialize = function(id, default = NO_DEF, tags = character(), custom_check = NULL) {
+    #' @param repr (`character(1)`)\cr
+    #'   Custom representation string. Used for parameter table in help pages.
+    initialize = function(id, default = NO_DEF, tags = character(), custom_check = NULL,
+                          repr = substitute(default)) {
       # super class calls private$.check, so this must be set BEFORE
       # we initialize the super class
       if (is.null(custom_check)) {
         self$custom_check = function(x) TRUE
       } else {
         self$custom_check = assert_function(custom_check, "x")
+      }
+      self$repr = if (!is_nodefault(default)) {
+         as.character(repr)
+      } else {
+        "NoDefault"
       }
       super$initialize(id, special_vals = list(), default = default, tags = tags)
     }

--- a/R/domain.R
+++ b/R/domain.R
@@ -157,7 +157,10 @@ p_dbl = function(lower = -Inf, upper = Inf, special_vals = list(), default = NO_
 #' @rdname Domain
 #' @export
 p_uty = function(default = NO_DEF, tags = character(), custom_check = NULL, depends = NULL, trafo = NULL) {
-  domain(constructor = ParamUty, constargs = as.list(match.call()[-1]),
+  # For better printing of untyped parameters
+  constargs = as.list(match.call()[-1])
+  if (!missing(default)) constargs$repr = as.character(substitute(default))
+  domain(constructor = ParamUty, constargs = constargs,
     depends_expr = substitute(depends), trafo = trafo)
 }
 

--- a/man/Domain.Rd
+++ b/man/Domain.Rd
@@ -153,7 +153,7 @@ A \code{Domain} object is a representation of a single dimension of a \code{\lin
 
 \code{Domain} objects are representations of parameter ranges and are intermediate objects to be used in short form
 constructions in \code{\link[=to_tune]{to_tune()}} and \code{\link[=ps]{ps()}}. Because of their nature, they should not be modified by the user.
-The \code{Domain} object's internals are subject to change and should not be relid upon.
+The \code{Domain} object's internals are subject to change and should not be relied upon.
 }
 \details{
 The \code{p_fct} function admits a \code{levels} argument that goes beyond the \code{levels} accepted by \code{\link{ParamFct}}\verb{$new()}.

--- a/man/ParamUty.Rd
+++ b/man/ParamUty.Rd
@@ -26,6 +26,9 @@ Other Params:
 \describe{
 \item{\code{custom_check}}{(\verb{function()})\cr
 Custom function to check the feasibility.}
+
+\item{\code{repr}}{(\code{character(1)})\cr
+Custom field for printing the parameter table.}
 }
 \if{html}{\out{</div>}}
 }
@@ -93,7 +96,13 @@ Always \code{"list"} for \link{ParamUty}.}
 \subsection{Method \code{new()}}{
 Creates a new instance of this \link[R6:R6Class]{R6} class.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParamUty$new(id, default = NO_DEF, tags = character(), custom_check = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParamUty$new(
+  id,
+  default = NO_DEF,
+  tags = character(),
+  custom_check = NULL,
+  repr = substitute(default)
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -124,6 +133,9 @@ Custom function to check the feasibility.
 Function which checks the input.
 Must return 'TRUE' if the input is valid and a string with the error message otherwise.
 Defaults to \code{NULL}, which means that no check is performed.}
+
+\item{\code{repr}}{(\code{character(1)})\cr
+Custom representation string. Used for parameter table in help pages.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Changes: 
* Column "type" now prints "untyped" instead of "list" for untyped params
* The representation of untyped parameters used substitute(default) to obtain the representation