### PR TITLE
fix: remove unused 'description' field from Param

### DIFF
--- a/R/Param.R
+++ b/R/Param.R
@@ -22,12 +22,6 @@ Param = R6Class("Param",
     #' Identifier of the object.
     id = NULL,
 
-    #' @field description (`character(1)`)\cr
-    #' String to describe this parameter. Used, for example, in [mlr3misc::rd_info()] to automatically
-    #' generate documentation for parameter sets.
-    description = NULL,
-
-
     #' @field special_vals (`list()`)\cr
     #' Arbitrary special values this parameter is allowed to take.
     special_vals = NULL,

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -31,10 +31,6 @@ Other Params:
 \item{\code{id}}{(\code{character(1)})\cr
 Identifier of the object.}
 
-\item{\code{description}}{(\code{character(1)})\cr
-String to describe this parameter. Used, for example, in \code{\link[mlr3misc:rd_info]{mlr3misc::rd_info()}} to automatically
-generate documentation for parameter sets.}
-
 \item{\code{special_vals}}{(\code{list()})\cr
 Arbitrary special values this parameter is allowed to take.}
 


### PR DESCRIPTION
Removes the field `description` from `Param` as it seems to be unused