### PR TITLE
feat: add getter and setter for initial values

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -189,6 +189,20 @@ ParamSet = R6Class("ParamSet",
     },
 
     #' @description
+    #' Sets the initial parameter values of the ParamSet.
+    #' This function should only be called once.
+    #' @param ... (named `list()`)\cr
+    #'   Initial parameter values.
+    set_initial_values = function(...) {
+      values = list(...)
+      init_values = map(values, function(x) if (test_r6(x)) x$clone(deep = TRUE) else x)
+      values = map(values, function(x) if (test_r6(x)) x$clone(deep = TRUE) else x)
+      self$set_values(.values = values)
+      private$.initial_values = init_values
+      invisible(self)
+    },
+
+    #' @description
     #' Changes the current set to the set of passed IDs.
     #'
     #' @param ids (`character()`).
@@ -443,6 +457,14 @@ ParamSet = R6Class("ParamSet",
       }
     },
 
+    #' @field initial_values (named `list()`)\cr
+    #'   Retrieves the initial values from the contained ParamSets.
+    #'   This will fail if the initial values were not set.
+    initial_values = function(rhs) {
+      assert_ro_binding(rhs)
+      private$.initial_values
+    },
+
     #' @field set_id (`character(1)`)\cr
     #' ID of this param set. Default `""`. Settable.
     set_id = function(v) {
@@ -631,6 +653,7 @@ ParamSet = R6Class("ParamSet",
     .set_id = NULL,
     .trafo = NULL,
     .params = NULL,
+    .initial_values = NULL,
     .values = named_list(),
     # is `TRUE` when function is passed to $trafo or .extra_trafo is set in ps()
     .has_extra_trafo = FALSE,

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -189,14 +189,14 @@ ParamSet = R6Class("ParamSet",
     },
 
     #' @description
-    #' Sets the initial parameter values of the ParamSet.
+    #' Sets the initial parameter values of the ParamSet. They are set in the slot `values` but
+    #' are also saved and can always be accessed using the slot `initial_values`.
     #' This function should only be called once.
     #' @param ... (named `list()`)\cr
     #'   Initial parameter values.
     set_initial_values = function(...) {
       values = list(...)
       init_values = map(values, function(x) if (test_r6(x)) x$clone(deep = TRUE) else x)
-      values = map(values, function(x) if (test_r6(x)) x$clone(deep = TRUE) else x)
       self$set_values(.values = values)
       private$.initial_values = init_values
       invisible(self)
@@ -653,7 +653,7 @@ ParamSet = R6Class("ParamSet",
     .set_id = NULL,
     .trafo = NULL,
     .params = NULL,
-    .initial_values = NULL,
+    .initial_values = list(),
     .values = named_list(),
     # is `TRUE` when function is passed to $trafo or .extra_trafo is set in ps()
     .has_extra_trafo = FALSE,

--- a/R/ParamSetCollection.R
+++ b/R/ParamSetCollection.R
@@ -93,8 +93,15 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
     #' Only included for consistency. Not allowed to perform on [ParamSetCollection]s.
     #'
     #' @param ids (`character()`).
-    subset = function(ids) stop("not allowed")
+    subset = function(ids) stop("not allowed"),
 
+    #' @description
+    #' Only contained for consistency. Set the initial values of the underlying ParamSets instead.
+    #' @param ... (any)\cr
+    #'   Not used.
+    set_initial_values = function(...) {
+      stopf("Setting initial values on ParamSetCollection is currently not supported.")
+    }
   ),
 
   active = list(
@@ -106,6 +113,19 @@ ParamSetCollection = R6Class("ParamSetCollection", inherit = ParamSet,
         x$id = n
         x
       })
+    },
+    #' @field initial_values (named `list()`)\cr
+    #'   Retrieves the initial values from the contained ParamSets.
+    #'   This will return `NULL` if at least one of the ParamSets does not have `initial_values`.
+    initial_values = function(rhs) {
+      assert_ro_binding(rhs)
+      sets = private$.sets
+      names(sets) = map_chr(sets, "set_id")
+      vals = map(sets, function(s) s$initial_values)
+      if (any(map_lgl(vals, is.null))) {
+        return(NULL)
+      }
+      unlist(vals, recursive = FALSE)
     },
     #' @template field_params_unid
     params_unid = function(v) {

--- a/man/ParamSet.Rd
+++ b/man/ParamSet.Rd
@@ -320,7 +320,8 @@ replace all values. Default is TRUE.}
 \if{html}{\out{<a id="method-ParamSet-set_initial_values"></a>}}
 \if{latex}{\out{\hypertarget{method-ParamSet-set_initial_values}{}}}
 \subsection{Method \code{set_initial_values()}}{
-Sets the initial parameter values of the ParamSet.
+Sets the initial parameter values of the ParamSet. They are set in the slot \code{values} but
+are also saved and can always be accessed using the slot \code{initial_values}.
 This function should only be called once.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ParamSet$set_initial_values(...)}\if{html}{\out{</div>}}

--- a/man/ParamSet.Rd
+++ b/man/ParamSet.Rd
@@ -74,6 +74,10 @@ Lists all (direct) dependency parents of a param, through parameter IDs.
 Internally created by a call to \code{add_dep}.
 Settable, if you want to remove dependencies or perform other changes.}
 
+\item{\code{initial_values}}{(named \code{list()})\cr
+Retrieves the initial values from the contained ParamSets.
+This will fail if the initial values were not set.}
+
 \item{\code{set_id}}{(\code{character(1)})\cr
 ID of this param set. Default \code{""}. Settable.}
 
@@ -171,6 +175,7 @@ Has the set parameter dependencies?}
 \item \href{#method-ParamSet-ids}{\code{ParamSet$ids()}}
 \item \href{#method-ParamSet-get_values}{\code{ParamSet$get_values()}}
 \item \href{#method-ParamSet-set_values}{\code{ParamSet$set_values()}}
+\item \href{#method-ParamSet-set_initial_values}{\code{ParamSet$set_initial_values()}}
 \item \href{#method-ParamSet-subset}{\code{ParamSet$subset()}}
 \item \href{#method-ParamSet-search_space}{\code{ParamSet$search_space()}}
 \item \href{#method-ParamSet-check}{\code{ParamSet$check()}}
@@ -307,6 +312,25 @@ Named list with parameter values. Names must not already appear in \code{...}.}
 \item{\code{.insert}}{(\code{logical(1)})\cr
 Whether to insert the values (old values are being kept, if not overwritten), or to
 replace all values. Default is TRUE.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ParamSet-set_initial_values"></a>}}
+\if{latex}{\out{\hypertarget{method-ParamSet-set_initial_values}{}}}
+\subsection{Method \code{set_initial_values()}}{
+Sets the initial parameter values of the ParamSet.
+This function should only be called once.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ParamSet$set_initial_values(...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{(named \code{list()})\cr
+Initial parameter values.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ParamSetCollection.Rd
+++ b/man/ParamSetCollection.Rd
@@ -164,7 +164,8 @@ Only included for consistency. Not allowed to perform on \link{ParamSetCollectio
 \if{html}{\out{<a id="method-ParamSetCollection-set_initial_values"></a>}}
 \if{latex}{\out{\hypertarget{method-ParamSetCollection-set_initial_values}{}}}
 \subsection{Method \code{set_initial_values()}}{
-Only contained for consistency. Set the initial values of the underlying ParamSets instead.
+Sets the initial parameter values of the underling \link{ParamSet}s.
+This function should only be called once.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ParamSetCollection$set_initial_values(...)}\if{html}{\out{</div>}}
 }

--- a/man/ParamSetCollection.Rd
+++ b/man/ParamSetCollection.Rd
@@ -37,6 +37,10 @@ If you call \code{deps} on the collection, you are returned a complete table of 
 \item{\code{params}}{(named \code{list()})\cr
 List of \link{Param}, named with their respective ID.}
 
+\item{\code{initial_values}}{(named \code{list()})\cr
+Retrieves the initial values from the contained ParamSets.
+This will return \code{NULL} if at least one of the ParamSets does not have \code{initial_values}.}
+
 \item{\code{params_unid}}{(named \code{list()})\cr
 List of \link{Param}, named with their true ID. However,
 this field has the \link{Param}'s \verb{$id} value set to a
@@ -64,6 +68,7 @@ When you set values, all previously set values will be unset / removed.}
 \item \href{#method-ParamSetCollection-add}{\code{ParamSetCollection$add()}}
 \item \href{#method-ParamSetCollection-remove_sets}{\code{ParamSetCollection$remove_sets()}}
 \item \href{#method-ParamSetCollection-subset}{\code{ParamSetCollection$subset()}}
+\item \href{#method-ParamSetCollection-set_initial_values}{\code{ParamSetCollection$set_initial_values()}}
 \item \href{#method-ParamSetCollection-clone}{\code{ParamSetCollection$clone()}}
 }
 }
@@ -151,6 +156,24 @@ Only included for consistency. Not allowed to perform on \link{ParamSetCollectio
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{ids}}{(\code{character()}).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ParamSetCollection-set_initial_values"></a>}}
+\if{latex}{\out{\hypertarget{method-ParamSetCollection-set_initial_values}{}}}
+\subsection{Method \code{set_initial_values()}}{
+Only contained for consistency. Set the initial values of the underlying ParamSets instead.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ParamSetCollection$set_initial_values(...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{(any)\cr
+Not used.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -419,5 +419,5 @@ test_that("set_initial_values works for ParamSet", {
   ps = ps(a = p_uty())
   par = ParamUty$new("test")
   ps$set_initial_values(a = par)
-  expect_false(identical(ps$values$a, par))
+  expect_false(identical(ps$initial_values$a, par))
 })

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -408,3 +408,16 @@ test_that("set_values works for .values and ... with correct inputs", {
   expect_true(param_set$values$b == 2)
   expect_true(param_set$values$c == 3)
 })
+
+test_that("set_initial_values works for ParamSet", {
+  # basic case works
+  ps = th_paramset_dbl1()
+  ps$set_initial_values(th_param_dbl = 1)
+  expect_identical(ps$initial_values, list(th_param_dbl = 1))
+
+  # r6 objects are cloned
+  ps = ps(a = p_uty())
+  par = ParamUty$new("test")
+  ps$set_initial_values(a = par)
+  expect_false(identical(ps$values$a, par))
+})

--- a/tests/testthat/test_ParamSetCollection.R
+++ b/tests/testthat/test_ParamSetCollection.R
@@ -271,3 +271,16 @@ test_that("set_id inference in values assignment works now", {
   expect_error(ParamSetCollection$new(list(pscol1, pstest)),
     "duplicated parameter.* a\\.c\\.paramc")
 })
+
+test_that("set_initial_values works for ParamSetCollection", {
+  ps1 = th_paramset_dbl1()
+  ps1$set_id = "s1"
+  ps1$set_initial_values(th_param_dbl = 0.2)
+  ps2 = th_paramset_full()
+  ps2$set_id = "s2"
+  psc = ParamSetCollection$new(list(ps1, ps2))
+
+  expect_true(is.null(psc$initial_values))
+  ps2$set_initial_values(th_param_dbl = 5)
+  expect_identical(psc$initial_values, list(s1.th_param_dbl = 0.2, s2.th_param_dbl = 5))
+})

--- a/tests/testthat/test_ParamSetCollection.R
+++ b/tests/testthat/test_ParamSetCollection.R
@@ -282,5 +282,4 @@ test_that("set_initial_values works for ParamSetCollection", {
   expect_identical(psc1$initial_values, list(s1.th_param_dbl = 1))
   psc1$set_initial_values(s2.th_param_dbl = 2)
   expect_identical(psc1$initial_values, list(s2.th_param_dbl = 2))
-  expect_identical(psc$initial_values, list())
 })

--- a/tests/testthat/test_ParamSetCollection.R
+++ b/tests/testthat/test_ParamSetCollection.R
@@ -275,12 +275,12 @@ test_that("set_id inference in values assignment works now", {
 test_that("set_initial_values works for ParamSetCollection", {
   ps1 = th_paramset_dbl1()
   ps1$set_id = "s1"
-  ps1$set_initial_values(th_param_dbl = 0.2)
   ps2 = th_paramset_full()
   ps2$set_id = "s2"
-  psc = ParamSetCollection$new(list(ps1, ps2))
-
-  expect_true(is.null(psc$initial_values))
-  ps2$set_initial_values(th_param_dbl = 5)
-  expect_identical(psc$initial_values, list(s1.th_param_dbl = 0.2, s2.th_param_dbl = 5))
+  ps1$set_initial_values(th_param_dbl = 1)
+  psc1 = ParamSetCollection$new(list(ps1, ps2))
+  expect_identical(psc1$initial_values, list(s1.th_param_dbl = 1))
+  psc1$set_initial_values(s2.th_param_dbl = 2)
+  expect_identical(psc1$initial_values, list(s2.th_param_dbl = 2))
+  expect_identical(psc$initial_values, list())
 })


### PR DESCRIPTION
* This can be useful if one (e.g. when tuning) wants to run the learner with the default configuration without reconstructing the learner.
* It can be checked whether a learner has defaults set, by doing  `is.null(param_set$initial_values)`.
* The `param_set$values = list(...)` in the learner / pipeops initialize function can simply be replaced with
`param_set$set_initial_values(...)`