### PR TITLE
fix: set_values allows to unset parameters.

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -182,10 +182,8 @@ ParamSet = R6Class("ParamSet",
       new_values = insert_named(dots, .values)
       if (.insert) {
         new_values = insert_named(self$values, new_values)
-        self$values = discard(new_values, function(x) is.null(x))
-      } else {
-        self$values = new_values
-      }
+      } 
+      self$values = discard(new_values, function(x) is.null(x))
       invisible(self)
     },
 

--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -181,7 +181,8 @@ ParamSet = R6Class("ParamSet",
       assert_disjunct(names(dots), names(.values))
       new_values = insert_named(dots, .values)
       if (.insert) {
-        self$values = insert_named(self$values, new_values)
+        new_values = insert_named(self$values, new_values)
+        self$values = discard(new_values, function(x) is.null(x))
       } else {
         self$values = new_values
       }

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -408,3 +408,10 @@ test_that("set_values works for .values and ... with correct inputs", {
   expect_true(param_set$values$b == 2)
   expect_true(param_set$values$c == 3)
 })
+
+test_that("set_values allows to unset parameters by setting them to NULL", {
+  param_set = ps(a = p_int())
+  param_set$set_values(a = 1)
+  param_set$set_values(a = NULL)
+  expect_true(length(param_set$values) == 0)
+})

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -414,4 +414,14 @@ test_that("set_values allows to unset parameters by setting them to NULL", {
   param_set$set_values(a = 1)
   param_set$set_values(a = NULL)
   expect_true(length(param_set$values) == 0)
+
+  param_set = ps(a = p_int())
+  param_set$set_values(a = 1)
+  param_set$set_values(.values = list(a = NULL))
+  expect_true(length(param_set$values) == 0)
+
+  param_set = ps(a = p_int())
+  param_set$set_values(a = 1)
+  param_set$set_values(.values = list(a = NULL), .insert = FALSE)
+  expect_true(length(param_set$values) == 0)
 })


### PR DESCRIPTION
Earlier it was not possible to unset parameters by setting them to `NULL` when using `param_set$set_values(par = NULL)`.