### PR TITLE
Add skip() for Suggests dependency required for test

### DIFF
--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -356,6 +356,8 @@ test_that("ParamSet$check_dt", {
 })
 
 test_that("rd_info.ParamSet", {
+  skip_if_not_installed("knitr")
+
   ps = ParamSet_legacy$new()
   expect_character(rd_info(ps), pattern = "empty", ignore.case = TRUE)
   ps = ps_union(list(ps, ParamFct$new("a", levels = letters[1:3])))


### PR DESCRIPTION
The dependency of the test on {knitr} can be hard to spot; this will also help make the dependency clearer.